### PR TITLE
Android App Deployment to Itch.io

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -87,6 +87,7 @@ jobs:
   deploy_app:
     name: Deploy to Itch.io
     needs: [ app_build_dev ]
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
       - name: Download SDK Artifact

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -11,8 +11,59 @@ on:
 concurrency: main_workflow
 
 jobs:
+  app_preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🏗 Setup repo
+        uses: actions/checkout@v3
+
+      - name: 🏗 Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+
+      - name: 🏗 Setup Expo
+        uses: expo/expo-github-action@v7
+        with:
+          expo-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: 📦 Install dependencies
+        run: npm install
+
+      - name: 🚀 Publish preview
+        run: expo publish --release-channel=pr-${{ github.event.number }} --non-interactive
+
+      - name: 💬 Comment preview
+        uses: expo/expo-github-action/preview-comment@v7
+        with:
+          channel: pr-${{ github.event.number }}
+  app_build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🏗 Setup repo
+        uses: actions/checkout@v3
+
+      - name: 🏗 Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+
+      - name: 🏗 Setup Expo and EAS
+        uses: expo/expo-github-action@v7
+        with:
+          expo-version: latest
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: 📦 Install dependencies
+        run: npm install
+
+      - name: 🚀 Build app
+        run: eas build --non-interactive --platform all
   deploy:
     name: Deploy to Vercel
+    needs: [ app_build, app_preview ]
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -38,7 +38,6 @@ jobs:
 
       - name: 💬 Comment preview
         uses: expo/expo-github-action/preview-comment@v7
-        working-directory: ./sudokuru
         with:
           channel: pr-${{ github.event.number }}
   app_build:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -11,7 +11,7 @@ on:
 concurrency: main_workflow
 
 jobs:
-  app_preview:
+  app_preview_dev:
     runs-on: ubuntu-latest
     steps:
       - name: 🏗 Setup repo

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -102,7 +102,7 @@ jobs:
           ./butler -V
 
       - name: Update Itch.io Android Alpha App
-        run: ./butler push . ${{secrets.ITCH_USERNAME}}/${{secrets.ITCH_GAME_ID}}:sudokuru-alpha-android
+        run: ./butler push . ${{secrets.ITCH_USERNAME}}/${{secrets.ITCH_GAME_ID}}:alpha-android
         env:
           BUTLER_API_KEY: ${{secrets.BUTLER_API_KEY}}
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -74,9 +74,6 @@ jobs:
           name: Android SDK
           path: sudokuru/Build/*.apk
 
-      - name: Display structure of downloaded files
-        run: ls -R
-
   deploy_app:
     name: Deploy to Itch.io
     needs: [ app_build, app_preview ]
@@ -89,6 +86,14 @@ jobs:
 
       - name: Display structure of downloaded files
         run: ls -R
+
+      - uses: KikimoraGames/itch-publish@v0.0.3
+        with:
+          butlerApiKey: ${{secrets.BUTLER_API_KEY}}
+          gameData: .
+          itchUsername: ${{env.ITCH_USERNAME}}
+          itchGameId: ${{ env.ITCH_GAME_ID }}
+          buildChannel: sudokuru-android
 
   deploy_website:
     name: Deploy to Vercel

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -72,13 +72,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: Android SDK
-          path: Build/*.apk
-
-      - name: Upload SDK Artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: Android SDK
-          path: Build
+          path: sudokuru/Build/*.apk
 
       - name: Display structure of downloaded files
         run: ls -R

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -36,11 +36,6 @@ jobs:
         run: expo publish --release-channel=pr-${{ github.event.number }} --non-interactive
         working-directory: ./sudokuru
 
-      - name: 💬 Comment preview
-        uses: expo/expo-github-action/preview-comment@v7
-        with:
-          channel: pr-${{ github.event.number }}
-
   app_build_dev:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -29,10 +29,12 @@ jobs:
           token: ${{ secrets.EXPO_TOKEN }}
 
       - name: 📦 Install dependencies
-        run: npm install
+        run: npm ci
+        working-directory: ./sudokuru
 
       - name: 🚀 Publish preview
         run: expo publish --release-channel=pr-${{ github.event.number }} --non-interactive
+        working-directory: ./sudokuru
 
       - name: 💬 Comment preview
         uses: expo/expo-github-action/preview-comment@v7
@@ -57,10 +59,12 @@ jobs:
           token: ${{ secrets.EXPO_TOKEN }}
 
       - name: 📦 Install dependencies
-        run: npm install
+        run: npm ci
+        working-directory: ./sudokuru
 
       - name: 🚀 Build app
         run: eas build --non-interactive --platform all
+        working-directory: ./sudokuru
   deploy:
     name: Deploy to Vercel
     needs: [ app_build, app_preview ]

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -119,7 +119,7 @@ jobs:
           itchGameId: ${{ secrets.ITCH_GAME_ID }}
           buildChannel: sudokuru-android
 
-  deploy_website:
+  deploy_website_prod:
     name: Deploy to Vercel
     needs: [ app_build ]
     if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -85,7 +85,7 @@ jobs:
 
   deploy_app:
     name: Deploy to Itch.io
-    needs: [ app_build ]
+    needs: [ app_build_dev ]
     runs-on: ubuntu-latest
     steps:
       - name: Download SDK Artifact
@@ -107,7 +107,7 @@ jobs:
 
   deploy_website_prod:
     name: Deploy to Vercel
-    needs: [ app_build ]
+    needs: [ app_build_dev ]
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -36,10 +36,11 @@ jobs:
         run: expo publish --release-channel=pr-${{ github.event.number }} --non-interactive
         working-directory: ./sudokuru
 
-#      - name: 💬 Comment preview
-#        uses: expo/expo-github-action/preview-comment@v7
-#        with:
-#          channel: pr-${{ github.event.number }}
+      - name: 💬 Comment preview
+        uses: expo/expo-github-action/preview-comment@v7
+        with:
+          channel: pr-${{ github.event.number }}
+
   app_build_dev:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -36,10 +36,10 @@ jobs:
         run: expo publish --release-channel=pr-${{ github.event.number }} --non-interactive
         working-directory: ./sudokuru
 
-      - name: 💬 Comment preview
-        uses: expo/expo-github-action/preview-comment@v7
-        with:
-          channel: pr-${{ github.event.number }}
+#      - name: 💬 Comment preview
+#        uses: expo/expo-github-action/preview-comment@v7
+#        with:
+#          channel: pr-${{ github.event.number }}
   app_build:
     runs-on: ubuntu-latest
     steps:
@@ -63,7 +63,7 @@ jobs:
         working-directory: ./sudokuru
 
       - name: 🚀 Build app
-        run: eas build --non-interactive --platform all
+        run: eas build --non-interactive --platform android
         working-directory: ./sudokuru
   deploy:
     name: Deploy to Vercel

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -29,7 +29,7 @@ jobs:
           token: ${{ secrets.EXPO_TOKEN }}
 
       - name: 📦 Install dependencies
-        run: npm ci
+        run: npm ci && npx expo install expo-updates
         working-directory: ./sudokuru
 
       - name: 🚀 Publish preview

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -88,7 +88,7 @@ jobs:
 
   deploy_app:
     name: Deploy to Itch.io
-    needs: [ app_build, app_preview ]
+    needs: [ app_build ]
     runs-on: ubuntu-latest
     steps:
       - name: Download SDK Artifact
@@ -121,7 +121,7 @@ jobs:
 
   deploy_website:
     name: Deploy to Vercel
-    needs: [ app_build, app_preview ]
+    needs: [ app_build ]
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -65,6 +65,8 @@ jobs:
       - name: 🚀 Build app
         run: eas build --non-interactive --platform android --local
         working-directory: ./sudokuru
+        env:
+          EAS_LOCAL_BUILD_ARTIFACTS_DIR: Build
 
 #      - uses: actions/upload-artifact@v3
 #        with:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -38,6 +38,7 @@ jobs:
 
       - name: 💬 Comment preview
         uses: expo/expo-github-action/preview-comment@v7
+        working-directory: ./sudokuru
         with:
           channel: pr-${{ github.event.number }}
   app_build:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -68,11 +68,26 @@ jobs:
         env:
           EAS_LOCAL_BUILD_ARTIFACTS_DIR: Build
 
-#      - uses: actions/upload-artifact@v3
-#        with:
-#          name: my-artifact
-#          path: output.txt
-  deploy:
+      - name: Upload SDK Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: Android SDK
+          path: Build/*.apk
+
+  deploy_app:
+    name: Deploy to Itch.io
+    needs: [ app_build, app_preview ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download SDK Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: Android SDK
+
+      - name: Display structure of downloaded files
+        run: ls -R
+
+  deploy_website:
     name: Deploy to Vercel
     needs: [ app_build, app_preview ]
     if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -107,7 +107,7 @@ jobs:
           ./butler -V
 
       - name: Update App
-        run: butler push . ${{secrets.ITCH_USERNAME}}/${{secrets.ITCH_GAME_ID}}:sudokuru-alpha-android
+        run: ./butler push . ${{secrets.ITCH_USERNAME}}/${{secrets.ITCH_GAME_ID}}:sudokuru-alpha-android
         env:
           BUTLER_API_KEY: ${{secrets.BUTLER_API_KEY}}
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -63,13 +63,13 @@ jobs:
         working-directory: ./sudokuru
 
       - name: 🚀 Build app
-        run: eas build --non-interactive --platform android > output.txt && cat output.txt
+        run: eas build --non-interactive --platform android --local
         working-directory: ./sudokuru
 
-      - uses: actions/upload-artifact@v3
-        with:
-          name: my-artifact
-          path: output.txt
+#      - uses: actions/upload-artifact@v3
+#        with:
+#          name: my-artifact
+#          path: output.txt
   deploy:
     name: Deploy to Vercel
     needs: [ app_build, app_preview ]

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -87,6 +87,13 @@ jobs:
       - name: Display structure of downloaded files
         run: ls -R
 
+      - name: Install Butler
+        run: |
+          curl -L -o butler.zip https://broth.itch.ovh/butler/linux-amd64/LATEST/archive/default
+          unzip butler.zip
+          chmod +x butler
+          ./butler -V
+
       - name: Update App
         run: butler push . ${{secrets.ITCH_USERNAME}}/${{secrets.ITCH_GAME_ID}}:sudokuru-android
         env:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -62,6 +62,15 @@ jobs:
         run: npm ci
         working-directory: ./sudokuru
 
+      - name: Add .env file
+        uses: SpicyPizza/create-envfile@v1.3
+        with:
+          envkey_SOME_DEV_DOMAIN: ${{ secrets.DEV_DOMAIN }}
+          envkey_SECRET_DEV_CLIENT_ID: ${{ secrets.DEV_CLIENT_ID }}
+          directory: sudokuru
+          file_name: .env
+          fail_on_empty: true
+
       - name: 🚀 Build app
         run: eas build --non-interactive --platform android --local
         working-directory: ./sudokuru

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -71,6 +71,9 @@ jobs:
           file_name: .env
           fail_on_empty: true
 
+      - name: Display structure of downloaded files
+        run: ls -R
+
       - name: 🚀 Build app
         run: eas build --non-interactive --platform android --local
         working-directory: ./sudokuru

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -17,6 +17,13 @@ jobs:
       - name: 🏗 Setup repo
         uses: actions/checkout@v3
 
+      - name: Post comment with preview link
+        uses: KeisukeYamashita/create-comment@v1
+        with:
+          comment: |
+            Preview App for PR:
+            https://expo.dev/@sudokuru/sudokuru?serviceType=classic&distribution=expo-go&release-channel=pr-${{ github.event.number }}
+
       - name: 🏗 Setup Node
         uses: actions/setup-node@v3
         with:
@@ -35,6 +42,13 @@ jobs:
       - name: 🚀 Publish preview
         run: expo publish --release-channel=pr-${{ github.event.number }} --non-interactive
         working-directory: ./sudokuru
+
+      - name: Post comment with preview link
+        uses: KeisukeYamashita/create-comment@v1
+        with:
+          comment: |
+            Preview App for PR:
+            https://expo.dev/@sudokuru/sudokuru?serviceType=classic&distribution=expo-go&release-channel=pr-${{ github.event.number }}
 
   app_build_dev:
     runs-on: ubuntu-latest

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -17,13 +17,6 @@ jobs:
       - name: 🏗 Setup repo
         uses: actions/checkout@v3
 
-      - name: Post comment with preview link
-        uses: KeisukeYamashita/create-comment@v1
-        with:
-          comment: |
-            Preview App for PR:
-            https://expo.dev/@sudokuru/sudokuru?serviceType=classic&distribution=expo-go&release-channel=pr-${{ github.event.number }}
-
       - name: 🏗 Setup Node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -95,7 +95,7 @@ jobs:
           ./butler -V
 
       - name: Update App
-        run: butler push . ${{secrets.ITCH_USERNAME}}/${{secrets.ITCH_GAME_ID}}:sudokuru-android
+        run: butler push . ${{secrets.ITCH_USERNAME}}/${{secrets.ITCH_GAME_ID}}:sudokuru-alpha-android
         env:
           BUTLER_API_KEY: ${{secrets.BUTLER_API_KEY}}
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -42,7 +42,6 @@ jobs:
 #          channel: pr-${{ github.event.number }}
   app_build:
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - name: 🏗 Setup repo
         uses: actions/checkout@v3
@@ -64,8 +63,13 @@ jobs:
         working-directory: ./sudokuru
 
       - name: 🚀 Build app
-        run: eas build --non-interactive --platform android
+        run: eas build --non-interactive --platform android > output.txt && cat output.txt
         working-directory: ./sudokuru
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: my-artifact
+          path: output.txt
   deploy:
     name: Deploy to Vercel
     needs: [ app_build, app_preview ]

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -42,6 +42,7 @@ jobs:
 #          channel: pr-${{ github.event.number }}
   app_build:
     runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - name: 🏗 Setup repo
         uses: actions/checkout@v3

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -71,9 +71,6 @@ jobs:
           file_name: .env
           fail_on_empty: true
 
-      - name: Display structure of downloaded files
-        run: ls -R
-
       - name: 🚀 Build app
         run: eas build --non-interactive --platform android --local
         working-directory: ./sudokuru
@@ -96,9 +93,6 @@ jobs:
         with:
           name: Android SDK
 
-      - name: Display structure of downloaded files
-        run: ls -R
-
       - name: Install Butler
         run: |
           curl -L -o butler.zip https://broth.itch.ovh/butler/linux-amd64/LATEST/archive/default
@@ -106,18 +100,10 @@ jobs:
           chmod +x butler
           ./butler -V
 
-      - name: Update App
+      - name: Update Itch.io Android Alpha App
         run: ./butler push . ${{secrets.ITCH_USERNAME}}/${{secrets.ITCH_GAME_ID}}:sudokuru-alpha-android
         env:
           BUTLER_API_KEY: ${{secrets.BUTLER_API_KEY}}
-
-      - uses: KikimoraGames/itch-publish@v0.0.3
-        with:
-          butlerApiKey: ${{secrets.BUTLER_API_KEY}}
-          gameData: .
-          itchUsername: ${{secrets.ITCH_USERNAME}}
-          itchGameId: ${{ secrets.ITCH_GAME_ID }}
-          buildChannel: sudokuru-android
 
   deploy_website_prod:
     name: Deploy to Vercel

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -40,7 +40,7 @@ jobs:
 #        uses: expo/expo-github-action/preview-comment@v7
 #        with:
 #          channel: pr-${{ github.event.number }}
-  app_build:
+  app_build_dev:
     runs-on: ubuntu-latest
     steps:
       - name: 🏗 Setup repo

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -87,12 +87,17 @@ jobs:
       - name: Display structure of downloaded files
         run: ls -R
 
+      - name: Update App
+        run: butler push . ${{secrets.ITCH_USERNAME}}/${{secrets.ITCH_GAME_ID}}:sudokuru-android
+        env:
+          BUTLER_API_KEY: ${{secrets.BUTLER_API_KEY}}
+
       - uses: KikimoraGames/itch-publish@v0.0.3
         with:
           butlerApiKey: ${{secrets.BUTLER_API_KEY}}
           gameData: .
-          itchUsername: ${{env.ITCH_USERNAME}}
-          itchGameId: ${{ env.ITCH_GAME_ID }}
+          itchUsername: ${{secrets.ITCH_USERNAME}}
+          itchGameId: ${{ secrets.ITCH_GAME_ID }}
           buildChannel: sudokuru-android
 
   deploy_website:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -74,6 +74,15 @@ jobs:
           name: Android SDK
           path: Build/*.apk
 
+      - name: Upload SDK Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: Android SDK
+          path: Build
+
+      - name: Display structure of downloaded files
+        run: ls -R
+
   deploy_app:
     name: Deploy to Itch.io
     needs: [ app_build, app_preview ]

--- a/sudokuru/README.md
+++ b/sudokuru/README.md
@@ -31,7 +31,8 @@ Preview mode can be run on any branch to preview how the site will look on Verce
 It is encouraged to use preview mode before merging changes into main.<br>
 
 ### Preview PR
-PR Previews can be viewed in the ```Publish Preview``` task of the ```app_preview``` job.<br>
+PR Previews can be viewed from the bot comment at the bottom of the PR.<br>
+PR Previews can also be viewed in the ```Publish Preview``` task of the ```app_preview``` job.<br>
 Here is an example preview URL: https://expo.dev/@sudokuru/sudokuru?serviceType=classic&distribution=expo-go&release-channel=pr-41<br>
 The URL will always be the same except for the release-channel name which will be ```pr-${{github.event.number}}```<br>
 

--- a/sudokuru/README.md
+++ b/sudokuru/README.md
@@ -21,6 +21,7 @@ For Web, hit the w key to start up the website at ```localhost:19006```
 
 # Deployments
 
+### Preview Branch
 In order to deploy your local branch in preview mode, run the following command:<br>
 ```npm run vercel:dev```<br>
 You will need to log in with our team email account.<br>
@@ -28,6 +29,13 @@ The console will output a preview url for viewing.<br>
 
 Preview mode can be run on any branch to preview how the site will look on Vercel.<br>
 It is encouraged to use preview mode before merging changes into main.<br>
+
+### Preview PR
+PR Previews can be viewed in the ```Publish Preview``` task of the ```app_preview``` job.<br>
+Here is an example preview URL: https://expo.dev/@sudokuru/sudokuru?serviceType=classic&distribution=expo-go&release-channel=pr-41<br>
+The URL will always be the same except for the release-channel name which will be ```pr-${{github.event.number}}```<br>
+
+
 
 
 ## This Project uses React-Native-Web. This means we will share code for the app and the website and avoid duplicating our work. 

--- a/sudokuru/app.config.ts
+++ b/sudokuru/app.config.ts
@@ -20,6 +20,7 @@ export default {
     name: 'Sudokuru',
     slug: 'sudokuru',
     scheme: 'sudokuru',
+    owner: "sudokuru",
     version: '1.0.0',
     platforms: [
         "ios",
@@ -33,6 +34,7 @@ export default {
         "**/*"
     ],
     ios: {
+        bundleIdentifier: "sudokuru.vercel.app",
         supportsTablet: true
     },
     android: {

--- a/sudokuru/app.config.ts
+++ b/sudokuru/app.config.ts
@@ -21,7 +21,7 @@ export default {
     slug: 'sudokuru',
     scheme: 'sudokuru',
     owner: "sudokuru",
-    version: '1.0.0',
+    version: '0.0.0',
     platforms: [
         "ios",
         "android"

--- a/sudokuru/app.config.ts
+++ b/sudokuru/app.config.ts
@@ -27,13 +27,16 @@ export default {
     ],
     orientation: "portrait",
     updates: {
-        "fallbackToCacheTimeout": 0
+        fallbackToCacheTimeout: 0
     },
     assetBundlePatterns: [
         "**/*"
     ],
     ios: {
-        "supportsTablet": true
+        supportsTablet: true
+    },
+    android: {
+        package: "sudokuru.vercel.app"
     },
     extra: {
         DOMAIN: process.env.DOMAIN,

--- a/sudokuru/app.config.ts
+++ b/sudokuru/app.config.ts
@@ -21,6 +21,26 @@ export default {
     slug: 'sudokuru',
     scheme: 'sudokuru',
     version: '1.0.0',
+    platforms: [
+        "ios",
+        "android"
+    ],
+    orientation: "portrait",
+    icon: "./assets/icon.png",
+    splash: {
+        image: "./assets/splash.png",
+        resizeMode: "contain",
+        backgroundColor: "#ffffff"
+    },
+    updates: {
+        "fallbackToCacheTimeout": 0
+    },
+    assetBundlePatterns: [
+        "**/*"
+    ],
+    ios: {
+        "supportsTablet": true
+    },
     extra: {
         DOMAIN: process.env.DOMAIN,
         CLIENT_ID: process.env.CLIENT_ID,

--- a/sudokuru/app.config.ts
+++ b/sudokuru/app.config.ts
@@ -26,12 +26,6 @@ export default {
         "android"
     ],
     orientation: "portrait",
-    icon: "./assets/icon.png",
-    splash: {
-        image: "./assets/splash.png",
-        resizeMode: "contain",
-        backgroundColor: "#ffffff"
-    },
     updates: {
         "fallbackToCacheTimeout": 0
     },

--- a/sudokuru/app.config.ts
+++ b/sudokuru/app.config.ts
@@ -24,5 +24,8 @@ export default {
     extra: {
         DOMAIN: process.env.DOMAIN,
         CLIENT_ID: process.env.CLIENT_ID,
+        eas: {
+            projectId: "23c4c607-ead6-4786-9a9c-03f57a97dac7"
+        }
     },
 };

--- a/sudokuru/eas.json
+++ b/sudokuru/eas.json
@@ -1,0 +1,18 @@
+{
+  "cli": {
+    "version": ">= 3.0.0"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+    },
+    "preview": {
+      "distribution": "internal"
+    },
+    "production": {}
+  },
+  "submit": {
+    "production": {}
+  }
+}

--- a/sudokuru/eas.json
+++ b/sudokuru/eas.json
@@ -8,9 +8,16 @@
       "distribution": "internal"
     },
     "preview": {
-      "distribution": "internal"
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      }
     },
-    "production": {}
+    "production": {
+      "android": {
+        "buildType": "apk"
+      }
+    }
   },
   "submit": {
     "production": {}

--- a/sudokuru/eas.json
+++ b/sudokuru/eas.json
@@ -15,7 +15,8 @@
     },
     "production": {
       "android": {
-        "buildType": "apk"
+        "buildType": "apk",
+        "autoIncrement": "version"
       }
     }
   },

--- a/sudokuru/eas.json
+++ b/sudokuru/eas.json
@@ -15,7 +15,7 @@
     },
     "production": {
       "android": {
-        "buildType": "apk",
+        "buildType": "apk"
       }
     }
   },

--- a/sudokuru/eas.json
+++ b/sudokuru/eas.json
@@ -16,7 +16,6 @@
     "production": {
       "android": {
         "buildType": "apk",
-        "autoIncrement": "version"
       }
     }
   },


### PR DESCRIPTION
Changelog: 
- Added ability to preview PR app without having to clone down the branch
- App will build and upload the APK file for each PR
- Added pipeline job to deploy Android app to Itch.io in an alpha channel