### PR TITLE
Removing App Preview for non-PR pipeline runs

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -12,6 +12,7 @@ concurrency: main_workflow
 
 jobs:
   app_preview_dev:
+    if: ${{ github.ref != 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
       - name: 🏗 Setup repo


### PR DESCRIPTION
We do not need to run the app preview after the PR has been completed.