### PR TITLE
Lesson Page/drill blob button fix

### DIFF
--- a/sudokuru/App.tsx
+++ b/sudokuru/App.tsx
@@ -13,18 +13,7 @@ import { NavigationContainer } from '@react-navigation/native';
 import { createDrawerNavigator, DrawerItem, DrawerItemList, DrawerContentScrollView,  DrawerContentComponentProps} from '@react-navigation/drawer';
 // theme imports
 import {CombinedDarkTheme, CombinedDefaultTheme} from './app/Styling/ThemeColors';
-import AdjustNotesLesson from "./app/Pages/Lessons/AdjustNotesLesson";
-import BoxLineReductionLesson from "./app/Pages/Lessons/BoxLineReductionLesson";
-import HiddenSetLesson from "./app/Pages/Lessons/HiddenSetLesson";
-import HiddenSingleLesson from "./app/Pages/Lessons/HiddenSingleLesson";
-import NakedSetLesson from "./app/Pages/Lessons/NakedSetLesson";
-import NakedSingleLesson from "./app/Pages/Lessons/NakedSingleLesson";
-import PointingPairLesson from "./app/Pages/Lessons/PointingPairLesson";
-import PointingTripletLesson from "./app/Pages/Lessons/PointingTripletLesson";
-import SimplifyNotesLesson from "./app/Pages/Lessons/SimplifyNotesLesson";
-import SinglesChainingLesson from "./app/Pages/Lessons/SinglesChainingLesson";
-import SwordfishLesson from "./app/Pages/Lessons/SwordfishLesson";
-import XWingLesson from "./app/Pages/Lessons/XWingLesson";
+import Lesson from "./app/Pages/Lesson";
 import DrillPage from './app/Pages/DrillPage';
 import CustomDrawerContent from './app/Components/Home/CustomDrawerContent';
 
@@ -85,7 +74,7 @@ function HomeDrawer(){
 
     return(
      <Drawer.Navigator initialRouteName="Main Page" initialRouteName="Home" drawerContent={(props) => (<CustomDrawerContent drawerItems={drawerItemsMain} {...props} />)}
-      screenOptions={{headerShown:false, headerTransparent:true, swipeEdgeWidth: 0, drawerPosition: "left", }}>
+      screenOptions={{headerShown:false, headerTransparent:true, swipeEdgeWidth: 0, drawerPosition: "left", unmountOnBlur:true }}>
                               <Drawer.Screen name="Main Page" component={HomePage} />
                               <Drawer.Screen name="Naked Single" initialParams={{ params: ["NAKED_SINGLE"] }} component={DrillPage} />
                               <Drawer.Screen name="Naked Pair" initialParams={{ params: ["NAKED_PAIR"] }} component={DrillPage} />
@@ -143,19 +132,7 @@ export default function App() {
                       <Stack.Screen name="Profile" component={ProfilePage} />
                       <Stack.Screen name="Statistics" component={StatisticsPage}/>
                       <Stack.Screen name="Sudoku" component={SudokuPage}/>
-
-                      <Stack.Screen name="AdjustNotesLesson" component={AdjustNotesLesson}/>
-                      <Stack.Screen name="BoxLineReductionLesson" component={BoxLineReductionLesson}/>
-                      <Stack.Screen name="HiddenSetLesson" component={HiddenSetLesson}/>
-                      <Stack.Screen name="HiddenSingleLesson" component={HiddenSingleLesson}/>
-                      <Stack.Screen name="NakedSetLesson" component={NakedSetLesson}/>
-                      <Stack.Screen name="NakedSingleLesson" component={NakedSingleLesson}/>
-                      <Stack.Screen name="PointingPairLesson" component={PointingPairLesson}/>
-                      <Stack.Screen name="PointingTripletLesson" component={PointingTripletLesson}/>
-                      <Stack.Screen name="SimplifyNotesLesson" component={SimplifyNotesLesson}/>
-                      <Stack.Screen name="SinglesChainingLesson" component={SinglesChainingLesson}/>
-                      <Stack.Screen name="SwordfishLesson" component={SwordfishLesson}/>
-                      <Stack.Screen name="XWingLesson" component={XWingLesson}/>
+                      <Stack.Screen name="Lesson" component={Lesson}/>
                   </Stack.Navigator>
               </NavigationContainer>
           </PaperProvider>

--- a/sudokuru/app/Components/Home/Carousel.tsx
+++ b/sudokuru/app/Components/Home/Carousel.tsx
@@ -21,34 +21,32 @@ const Ccarousel = () =>{
     const [index, setIndex] = useState(0);
 
     function navigate(index: number):any {
-        index == 0 ? navigation.navigate('AdjustNotesLesson') :
-            index == 1 ? navigation.navigate('SimplifyNotesLesson') :
-                index == 2 ? navigation.navigate('NakedSingleLesson') :
-                    index == 3 ? navigation.navigate('HiddenSingleLesson') :
-                        index == 4 ? navigation.navigate('NakedSetLesson') :
-                            index == 5 ? navigation.navigate('HiddenSetLesson') :
-                                index == 6 ? navigation.navigate('PointingPairLesson') :
-                                    index == 7 ? navigation.navigate('PointingTripletLesson') :
-                                        index == 8 ? navigation.navigate('BoxLineReductionLesson') :
-                                            index == 9 ? navigation.navigate('XWingLesson') :
-                                                index == 10 ? navigation.navigate('SwordfishLesson') :
-                                                    index == 11 ? navigation.navigate('SinglesChainingLesson') : navigation.navigate('Home');
+        index == 0 ? navigation.navigate('Lesson',{params:'AMEND_NOTES'}) :
+            index == 1 ? navigation.navigate('Lesson',{params:'SIMPLIFY_NOTES'}) :
+                index == 2 ? navigation.navigate('Lesson',{params:'NAKED_SINGLE'}) :
+                    index == 3 ? navigation.navigate('Lesson',{params:'NAKED_SET'}) :
+                        index == 4 ? navigation.navigate('Lesson',{params:'HIDDEN_SINGLE'}) :
+                            index == 5 ? navigation.navigate('Lesson',{params:'HIDDEN_SET'}) :
+                                index == 6 ? navigation.navigate('Lesson',{params:'POINTING_PAIR'}) :
+                                    index == 7 ? navigation.navigate('Lesson',{params:'BOX_LINE_REDUCTION'}) :
+                                        index == 8 ? navigation.navigate('Lesson',{params:'SWORDFISH'}) :
+                                            index == 9 ? navigation.navigate('Lesson',{params:'X_WING'}) :
+                                                index == 10 ? navigation.navigate('Lesson',{params:'SINGLES_CHAINING'}) : navigation.navigate('Home');
     };
 
     function getLessonName(index: number):string {
         let lessonName: string;
-        index == 0 ? lessonName = 'AdjustNotesLesson' :
-            index == 1 ? lessonName = 'SimplifyNotesLesson' :
-                index == 2 ? lessonName = 'NakedSingleLesson' :
-                    index == 3 ? lessonName = 'HiddenSingleLesson' :
-                        index == 4 ? lessonName = 'NakedSetLesson' :
-                            index == 5 ? lessonName = 'HiddenSetLesson' :
-                                index == 6 ? lessonName = 'PointingPairLesson' :
-                                    index == 7 ? lessonName = 'PointingTripletLesson' :
-                                        index == 8 ? lessonName = 'BoxLineReductionLesson' :
-                                            index == 9 ? lessonName = 'XWingLesson' :
-                                                index == 10 ? lessonName = 'SwordfishLesson' :
-                                                    index == 11 ? lessonName = 'SinglesChainingLesson' : lessonName = 'Null';
+        index == 0 ? lessonName = 'Amend Notes' :
+            index == 1 ? lessonName = 'Simplify Notes' :
+                index == 2 ? lessonName = 'Naked Single' :
+                    index == 3 ? lessonName = 'Naked Set' :
+                        index == 4 ? lessonName = 'Hidden Single' :
+                            index == 5 ? lessonName = 'Hidden Set' :
+                                index == 6 ? lessonName = 'Pointing Pair' :
+                                    index == 7 ? lessonName = 'Box Line Reduction' :
+                                        index == 8 ? lessonName = 'X Wing' :
+                                            index == 9 ? lessonName = 'Swordfish' :
+                                                index == 10 ? lessonName = 'Singles Chaining' : lessonName = 'Null';
         return lessonName;
     }
 
@@ -61,7 +59,7 @@ const Ccarousel = () =>{
                     height={width / 4}
                     ref={ref}
                     autoPlay={false}
-                    data={[...new Array(12).keys()]}
+                    data={[...new Array(11).keys()]}
                     mode='parallax'
                     modeConfig={{
                       parallaxScrollingScale: 0.5,
@@ -109,7 +107,7 @@ const Ccarousel = () =>{
                         height={width / 1.5}
                         ref={ref}
                         autoPlay={false}
-                        data={[...new Array(6).keys()]}
+                        data={[...new Array(11).keys()]}
                         mode='parallax'
                         modeConfig={{
                           parallaxScrollingScale: 0.8,

--- a/sudokuru/app/Pages/DrillPage.tsx
+++ b/sudokuru/app/Pages/DrillPage.tsx
@@ -177,11 +177,13 @@ const navigation: any = useNavigation();
     <SafeAreaProvider>
       <SafeAreaView>
 
-        <Header page={'Sudoku'}/>
-        <View style={homeScreenStyles.home}>
-         <Button style={{top:0}} mode="contained" onPress={() => navigation.goBack()}>
+         <Button style={styles.backButton} mode="contained" onPress={() => navigation.goBack()}>
                             Back
          </Button>
+
+        <Header page={'Sudoku'}/>
+        <View style={homeScreenStyles.home}>
+
           <View style={styles.container}>
             {/* The game now required the info about it to be rendered, which is given in generateGame() */}
             <SudokuBoard generatedGame={generateGame(USERACTIVEGAMESBFFURL,  ["HIDDEN_SINGLE"])} isDrill={true} getHint={getHint}/>
@@ -215,6 +217,12 @@ const styles = StyleSheet.create({
         flex: 1,
         alignItems: 'center',
         justifyContent: 'center',
+    },
+    backButton: {
+        paddingHorizontal: 5,
+        paddingVertical: 5,
+        top: 100,
+        position: 'absolute',
     },
 });
 

--- a/sudokuru/app/Pages/Lesson.tsx
+++ b/sudokuru/app/Pages/Lesson.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+import {StyleSheet, View, Image, FlatList} from "react-native";
+import {StatusBar} from "expo-status-bar";
+
+import Header from "../Components/Header";
+import { Text, Button } from 'react-native-paper';
+
+const sudokuru = require("../../node_modules/sudokuru/dist/bundle.js"); // -- What works for me
+const Lessons = sudokuru.Lessons;
+
+const Lesson = (props) => {
+      //Brings in name of strategy from carousel
+      let name = props.route.params ? props.route.params.params : "no props.route.params in LessonPage"
+      console.log(name);
+
+      let arr = Lessons.strategies;
+
+      //2d array that has text and image urls ---- 1st array - text, 2nd array - image url
+      let teach = [[],[]]
+      teach = Lessons.getSteps(name);
+
+      const [count, setCount]  = useState(0);
+
+      return (
+          <View>
+              <Header page={'Lesson'}/>
+              <View style={homeScreenStyles.home}>
+                  <View style={homeScreenStyles.lessons}>
+                       <View style={styles.container1}>
+
+                          {/*Shifts teach array*/}
+                          <Button style={{right:150, top:40}} mode="contained" onPress={() => setCount(count - 1)}>
+                            left
+                          </Button>
+                          <Button style={{left:150}} mode="contained" onPress={() =>setCount(count + 1)}>
+                            right
+                          </Button>
+
+                          <Text>
+                          <Text>{name}</Text>
+                          <Text>{" Lesson"}</Text>
+                          </Text>
+                          <Image
+                          style={{width: 400, height: 512}}
+                          source={{uri:teach[count][1]}}
+                          />
+                          <Text>{teach[count][0]}</Text>
+                      </View>
+                  </View>
+              </View>
+          </View>
+      );
+};
+
+const styles = StyleSheet.create({
+      container1: {
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'center',
+      },
+});
+
+const homeScreenStyles = StyleSheet.create({
+      home: {
+          display: "flex",
+          flexDirection: 'row',
+          //backgroundColor: 'red',
+      },
+      homeMenu: {
+          //backgroundColor: 'red',
+          width: "15%",
+      },
+      lessons: {
+          //backgroundColor: 'blue',
+          width: "85%",
+          alignContent: "flex-start",
+          flexDirection: 'row',
+          flexWrap: "wrap",
+      },
+});
+
+export default Lesson;

--- a/sudokuru/app/Pages/Lesson.tsx
+++ b/sudokuru/app/Pages/Lesson.tsx
@@ -21,6 +21,9 @@ const Lesson = (props) => {
 
       const [count, setCount]  = useState(0);
 
+      console.log(teach);
+
+      if(teach){
       return (
           <View>
               <Header page={'Lesson'}/>
@@ -49,7 +52,32 @@ const Lesson = (props) => {
                   </View>
               </View>
           </View>
+      );}
+
+       //NULL
+      else {
+      return(
+          <View>
+              <Header page={'Lesson'}/>
+              <View style={homeScreenStyles.home}>
+                  <View style={homeScreenStyles.lessons}>
+                       <View style={styles.container1}>
+
+                          <Text>
+                          <Text>{"CAT"}</Text>
+                          <Text>{" Lesson"}</Text>
+                          </Text>
+                          <Image
+                          style={{width: 400, height: 512}}
+                          source={{uri:"https://i.natgeofe.com/n/548467d8-c5f1-4551-9f58-6817a8d2c45e/NationalGeographic_2572187_square.jpg"}}
+                          />
+                          <Text>{name}</Text>
+                      </View>
+                  </View>
+              </View>
+          </View>
       );
+      }
 };
 
 const styles = StyleSheet.create({

--- a/sudokuru/package-lock.json
+++ b/sudokuru/package-lock.json
@@ -38,7 +38,7 @@
         "react-native-safe-area-context": "4.5.0",
         "react-native-screens": "~3.20.0",
         "react-native-web": "~0.18.12",
-        "sudokuru": "^1.5.0"
+        "sudokuru": "^1.5.4"
       },
       "devDependencies": {
         "@babel/core": "^7.20.0",
@@ -17489,9 +17489,9 @@
       "integrity": "sha512-rlBo3HU/1zAJUrkY6jNxDOC9eVYliG6nS4JA8u8KAshITd07tafMc/Br7xQwCSseXwJ2iCcHCE8SNWX3q8Z+kw=="
     },
     "node_modules/sudokuru": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/sudokuru/-/sudokuru-1.5.0.tgz",
-      "integrity": "sha512-8mOkEuINIqYctocynUlwVHLA5wI0wsWPR4dnoBuuG2pGJpygAXNI7BrCCCH8qg03O7B4DVrKYEE3DQ0kvWM3HA==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/sudokuru/-/sudokuru-1.5.4.tgz",
+      "integrity": "sha512-aSUo1nrPacg8YEXyFnoa2P96p2q0m/axxZp570vzfzE1hEWk97Ow8d8RyPAo1bH8AN+K4NC77l2iUS8QyAj4RA==",
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
@@ -32709,9 +32709,9 @@
       "integrity": "sha512-rlBo3HU/1zAJUrkY6jNxDOC9eVYliG6nS4JA8u8KAshITd07tafMc/Br7xQwCSseXwJ2iCcHCE8SNWX3q8Z+kw=="
     },
     "sudokuru": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/sudokuru/-/sudokuru-1.5.0.tgz",
-      "integrity": "sha512-8mOkEuINIqYctocynUlwVHLA5wI0wsWPR4dnoBuuG2pGJpygAXNI7BrCCCH8qg03O7B4DVrKYEE3DQ0kvWM3HA==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/sudokuru/-/sudokuru-1.5.4.tgz",
+      "integrity": "sha512-aSUo1nrPacg8YEXyFnoa2P96p2q0m/axxZp570vzfzE1hEWk97Ow8d8RyPAo1bH8AN+K4NC77l2iUS8QyAj4RA==",
       "requires": {
         "cors": "^2.8.5",
         "express": "^4.18.2",

--- a/sudokuru/package.json
+++ b/sudokuru/package.json
@@ -42,7 +42,7 @@
     "react-native-safe-area-context": "4.5.0",
     "react-native-screens": "~3.20.0",
     "react-native-web": "~0.18.12",
-    "sudokuru": "^1.5.0"
+    "sudokuru": "^1.5.4"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
Created a Lesson Page accessed from the Carousel. Lesson page currently displays lesson title, image and text from Lessons.getSteps and is able shift left and right. Also fixed back button blob on drill page. Need to set a min and max on count for useState because it can go into undefined values currently which causes a white screen. Probably can delete lessons folder inside the pages folder as well.

## Checklist for completing pull request:
- [ ] Test functionality on Android and web (iOS optional but encouraged)
- [ ] Verify that any unit tests for new functionality are created and functional.
- [ ] If needed, update the Readme