### PR TITLE
Resume Game/Prefilled Value Bugfix

### DIFF
--- a/sudokuru/app/Components/Sudoku Board/sudoku.ts
+++ b/sudokuru/app/Components/Sudoku Board/sudoku.ts
@@ -15,10 +15,11 @@ export function makeCountObject() {
     return countObj;
 }
 
-export function makeBoard({ puzzle }) {
+export function makeBoard({ puzzle }, initialPuzzle) {
     const rows = Array.from(Array(9).keys()).map(() => makeCountObject());
     const columns = Array.from(Array(9).keys()).map(() => makeCountObject());
     const squares = Array.from(Array(9).keys()).map(() => makeCountObject());
+    const initialPuzzleArray = initialPuzzle.match(/.{1,9}/g).map(row => row.split('').map(Number));
     const result = puzzle.map((row, i) => (
         row.map((cell, j) => {
             if (cell) {
@@ -28,10 +29,11 @@ export function makeBoard({ puzzle }) {
             }
             return {
                 value: puzzle[i][j] > 0 ? puzzle[i][j] : null,
-                prefilled: !!puzzle[i][j],
+                prefilled: !!initialPuzzleArray[j][i],
             };
         })
     ));
+    console.log(initialPuzzle);
     return fromJS({ puzzle: result, selected: false, inNoteMode: false, choices: { rows, columns, squares } });
 }
 

--- a/sudokuru/app/Pages/SudokuPage.tsx
+++ b/sudokuru/app/Pages/SudokuPage.tsx
@@ -51,7 +51,7 @@ const SudokuPage = ({route, navigation}) => { // TODO: Take in props from previo
         if (gameOrigin == "start"){
             gameData = await Puzzles.startGame(url, difficulty, strategies, token).then(
                 game => {
-                    let board = makeBoard(strPuzzleToArray(game[0].puzzle));
+                    let board = makeBoard(strPuzzleToArray(game[0].puzzle), game[0].puzzle);
                     return {
                         board,
                         history: List.of(board),
@@ -65,7 +65,7 @@ const SudokuPage = ({route, navigation}) => { // TODO: Take in props from previo
         else if (gameOrigin == "resume"){
             gameData = await Puzzles.getGame(url, token).then(
                 game => {
-                    let board = makeBoard(strPuzzleToArray(game[0].moves[game[0].moves.length-1].puzzleCurrentState));
+                    let board = makeBoard(strPuzzleToArray(game[0].moves[game[0].moves.length-1].puzzleCurrentState), game[0].puzzle);
                     board = parseApiAndAddNotes(board, game[0].moves[game[0].moves.length-1].puzzleCurrentNotesState, false);
                     return {
                         board,


### PR DESCRIPTION
Previously, the board determined whether a value was prefilled based on if that cell stored a value when drawing the cell. Now, that determination is done off of the initial state of the board, so when a user resumes a game with values filled, those values can still be changed.