### PR TITLE
Fixing resumePuzzle button rendering location

### DIFF
--- a/sudokuru/app/Pages/HomePage.tsx
+++ b/sudokuru/app/Pages/HomePage.tsx
@@ -119,10 +119,10 @@ const HomePage = () => {
                             <DifficultySlider />
                         </View>
 
-                        <View style={{top: reSize/2}}>
+                        <View style={{top: reSize/2, flexDirection: 'row'}}>
                             {
                                 (resumeVisible) ?
-                                    <Button style={{top:reSize/2, right: reSize}} mode="outlined" onPress={() => navigation.navigate('Sudoku', {gameOrigin: "resume"})}>
+                                    <Button style={{right: reSize}} mode="outlined" onPress={() => navigation.navigate('Sudoku', {gameOrigin: "resume"})}>
                                         Resume Puzzle
                                     </Button> : <></>
                             }


### PR DESCRIPTION
Changelog:
My previous PR messed up the render location of ResumeGame button, this is now fixed. 
## Checklist for completing pull request:
- [x] Test functionality on Android and web (iOS optional but encouraged)
- [ ] Verify that any unit tests for new functionality are created and functional.
- [ ] If needed, update the Readme