### PR TITLE
Drills no longer save state of previous drill sessons

### DIFF
--- a/sudokuru/App.tsx
+++ b/sudokuru/App.tsx
@@ -50,7 +50,7 @@ function HomeDrawer(){
 
     return(
      <Drawer.Navigator initialRouteName="Home" drawerContent={(props) => (<CustomDrawerContent drawerItems={drawerItemsMain} {...props} />)}
-      screenOptions={{headerShown:false, headerTransparent:true, swipeEdgeWidth: 0, drawerPosition: "left", }}>
+      screenOptions={{headerShown:false, headerTransparent:true, swipeEdgeWidth: 0, drawerPosition: "left", unmountOnBlur:true}}>
           <Drawer.Screen name="Main Page" component={HomePage} />
           <Drawer.Screen name="Naked Single" initialParams={{ params: ["NAKED_SINGLE"] }} component={DrillPage} />
           <Drawer.Screen name="Naked Pair" initialParams={{ params: ["NAKED_PAIR"] }} component={DrillPage} />


### PR DESCRIPTION
- added "unmountOnBlur:true" to drawer's screenOptions
- need to test to see if this will interrupt resume game maybe?

## Checklist for completing pull request:
- [ ] Test functionality on Android and web (iOS optional but encouraged)
- [ ] Verify that any unit tests for new functionality are created and functional.
- [ ] If needed, update the Readme