### PR TITLE
Lesson page changes

### DIFF
--- a/sudokuru/app/Pages/LandingPage.tsx
+++ b/sudokuru/app/Pages/LandingPage.tsx
@@ -18,12 +18,18 @@ const LandingPage = () => {
     const [visible, setVisible] = React.useState(false);
     const showModal = () => setVisible(true);
     const hideModal = () => setVisible(false);
+    const newUser = 1;
 
     async function canProceed() {
         await getTokenName().then(
             result => {
                 if (result != ""){
+                    if(newUser == 1){
                     navigation.navigate('Home');
+                    }
+                    else{
+                    navigation.navigate('Lesson',{params:'AMEND_NOTES'});
+                    }
                 } else {
                     showModal();
                 }

--- a/sudokuru/app/Pages/Lesson.tsx
+++ b/sudokuru/app/Pages/Lesson.tsx
@@ -64,6 +64,81 @@ const Lesson = (props: { route: { params: { params: any; }; }; }) => {
 
       }
 
+      //Separate view for mobile and web
+      const Page = () => {
+          //web view
+          if(Platform.OS === 'web'){
+            return(
+            <View style={styles.container1}>
+                  <View style={{ justifyContent: 'center', flexDirection: 'row'}}>
+
+                      <Pressable style={{top: reSize/4.5, height: reSize/10, right: reSize/25}} disabled={count - 1 == -1} onPress={() => setCount(count - 1)}>
+                          <AntDesign color= {(count - 1 == -1) ? theme.colors.background : theme.colors.onPrimary} name="leftcircleo" size={reSize/15}/>
+                      </Pressable>
+
+                      {
+                          (teach[count][1] != null) ?
+                              <Image
+                                  style={{width: reSize/2, height: reSize/2}}
+                                  source={{uri:teach[count][1]}}
+                              /> : <></>
+                      }
+
+                      <Pressable style={{top: reSize/4.5, height: reSize/10, left: reSize/25}} onPress={() => setCount(count + 1)} disabled={count + 1 == teach.length}>
+                          <AntDesign color={(count + 1 == teach.length) ? theme.colors.background : theme.colors.onPrimary} name="rightcircleo" size={reSize/15}/>
+                      </Pressable>
+                  </View>
+                  <Text>{" "}</Text>
+                  <View style={{width: reSize/1.5}}>
+                      {
+                          (teach[count][0] != null) ?
+                              <Text style={{color: theme.colors.onPrimary, textAlign: 'justify', fontSize: size.height/50}}>{teach[count][0]}</Text>
+                              : <></>
+                      }
+                  </View>
+            </View>
+            )
+          }
+
+          //mobile view
+          else{
+              return(
+                <View style={styles.container1}>
+                      {
+                          (teach[count][1] != null) ?
+                              <Image
+                                  style={{width: reSize/1.3, height: reSize/1.3}}
+                                  source={{uri:teach[count][1]}}
+                              /> : <></>
+                      }
+
+                      <Text>{" "}</Text>
+
+                      <View style={{ justifyContent:'center', flexDirection: 'row'}}>
+
+                          <Pressable style={{top: reSize/1.8, height: reSize/8, left: reSize/10}} disabled={count - 1 == -1} onPress={() => setCount(count - 1)}>
+                              <AntDesign color= {(count - 1 == -1) ? theme.colors.background : theme.colors.onPrimary} name="leftcircleo" size={reSize/10}/>
+                          </Pressable>
+
+                            <View style={{width: reSize/1.2}}>
+                                {
+                                    (teach[count][0] != null) ?
+                                        <Text style={{color: theme.colors.onPrimary, textAlign: 'justify', fontSize: size.height/50}}>{teach[count][0]}</Text>
+                                        : <></>
+                                }
+                            </View>
+
+                          <Pressable style={{top: reSize/1.8, height: reSize/8, right: reSize/10}} onPress={() => setCount(count + 1)} disabled={count + 1 == teach.length}>
+                              <AntDesign color={(count + 1 == teach.length) ? theme.colors.background : theme.colors.onPrimary} name="rightcircleo" size={reSize/10}/>
+                          </Pressable>
+                      </View>
+
+                </View>
+              )
+          }
+      }
+
+
       return (
           <SafeAreaProvider>
               <SafeAreaView style={{height: '100%', width: '100%'}}>
@@ -78,33 +153,8 @@ const Lesson = (props: { route: { params: { params: any; }; }; }) => {
                               </Pressable>
                           </View>
 
-                          <View style={{ justifyContent: 'center', flexDirection: 'row'}}>
+                          <Page/>
 
-                              <Pressable style={{top: reSize/4.5, height: reSize/10, right: reSize/25}} disabled={count - 1 == -1} onPress={() => setCount(count - 1)}>
-                                  <AntDesign color= {(count - 1 == -1) ? theme.colors.background : theme.colors.onPrimary} name="leftcircleo" size={reSize/15}/>
-                              </Pressable>
-
-                              {
-                                  (teach[count][1] != null) ?
-                                      <Image
-                                          style={{width: reSize/2, height: reSize/2}}
-                                          source={{uri:teach[count][1]}}
-                                      /> : <></>
-                              }
-
-                              <Pressable style={{top: reSize/4.5, height: reSize/10, left: reSize/25}} onPress={() => setCount(count + 1)} disabled={count + 1 == teach.length}>
-                                  <AntDesign color={(count + 1 == teach.length) ? theme.colors.background : theme.colors.onPrimary} name="rightcircleo" size={reSize/15}/>
-                              </Pressable>
-
-                          </View>
-                          <Text>{" "}</Text>
-                          <View style={{width: reSize/1.5}}>
-                              {
-                                  (teach[count][0] != null) ?
-                                      <Text style={{color: theme.colors.onPrimary, textAlign: 'justify', fontSize: size.height/50}}>{teach[count][0]}</Text>
-                                      : <></>
-                              }
-                          </View>
                       </View>
                   </View>
                   <Alert

--- a/sudokuru/app/Pages/Lesson.tsx
+++ b/sudokuru/app/Pages/Lesson.tsx
@@ -116,7 +116,7 @@ const Lesson = (props: { route: { params: { params: any; }; }; }) => {
 
                       <View style={{ justifyContent:'center', flexDirection: 'row'}}>
 
-                          <Pressable style={{top: reSize/1.8, height: reSize/8, left: reSize/10}} disabled={count - 1 == -1} onPress={() => setCount(count - 1)}>
+                          <Pressable style={{top: reSize/2, height: reSize/8, left: reSize/10}} disabled={count - 1 == -1} onPress={() => setCount(count - 1)}>
                               <AntDesign color= {(count - 1 == -1) ? theme.colors.background : theme.colors.onPrimary} name="leftcircleo" size={reSize/10}/>
                           </Pressable>
 
@@ -128,7 +128,7 @@ const Lesson = (props: { route: { params: { params: any; }; }; }) => {
                                 }
                             </View>
 
-                          <Pressable style={{top: reSize/1.8, height: reSize/8, right: reSize/10}} onPress={() => (count + 1 == teach.length) ? navigation.navigate("Home") :setCount(count + 1)} >
+                          <Pressable style={{top: reSize/2, height: reSize/8, right: reSize/10}} onPress={() => (count + 1 == teach.length) ? navigation.navigate("Home") :setCount(count + 1)} >
                               <AntDesign color={theme.colors.onPrimary} name={(count + 1 == teach.length) ? "checkcircleo" : "rightcircleo"} size={reSize/10}/>
                           </Pressable>
                       </View>

--- a/sudokuru/app/Pages/Lesson.tsx
+++ b/sudokuru/app/Pages/Lesson.tsx
@@ -84,8 +84,8 @@ const Lesson = (props: { route: { params: { params: any; }; }; }) => {
                               /> : <></>
                       }
 
-                      <Pressable style={{top: reSize/4.5, height: reSize/10, left: reSize/25}} onPress={() => setCount(count + 1)} disabled={count + 1 == teach.length}>
-                          <AntDesign color={(count + 1 == teach.length) ? theme.colors.background : theme.colors.onPrimary} name="rightcircleo" size={reSize/15}/>
+                      <Pressable style={{top: reSize/4.5, height: reSize/10, left: reSize/25}} onPress={() => (count + 1 == teach.length) ? navigation.navigate("Home") :setCount(count + 1)} >
+                          <AntDesign color={theme.colors.onPrimary} name={(count + 1 == teach.length) ? "checkcircleo" : "rightcircleo"} size={reSize/15}/>
                       </Pressable>
                   </View>
                   <Text>{" "}</Text>
@@ -128,8 +128,8 @@ const Lesson = (props: { route: { params: { params: any; }; }; }) => {
                                 }
                             </View>
 
-                          <Pressable style={{top: reSize/1.8, height: reSize/8, right: reSize/10}} onPress={() => setCount(count + 1)} disabled={count + 1 == teach.length}>
-                              <AntDesign color={(count + 1 == teach.length) ? theme.colors.background : theme.colors.onPrimary} name="rightcircleo" size={reSize/10}/>
+                          <Pressable style={{top: reSize/1.8, height: reSize/8, right: reSize/10}} onPress={() => (count + 1 == teach.length) ? navigation.navigate("Home") :setCount(count + 1)} >
+                              <AntDesign color={theme.colors.onPrimary} name={(count + 1 == teach.length) ? "checkcircleo" : "rightcircleo"} size={reSize/10}/>
                           </Pressable>
                       </View>
 


### PR DESCRIPTION
Changelog:

- Changed mobile layout for lessons, put navigation arrows on the bottom of the screen.
- Character limit should be around 350 for lessons? Maybe test on a smaller screen phone to see if size scaling works properly.
- Right arrow changes into a check mark at the end of the lesson and navigates user back to home screen.
- Setup navigation to Amend notes from Landing Page.

fixes #146 
fixes #148
fixes #150 

## Checklist for completing pull request:
- [x] Test functionality on Android and web (iOS optional but encouraged)
- [ ] Verify that any unit tests for new functionality are created and functional.
- [ ] If needed, update the Readme