### PR TITLE
Adding Hint name and description in hint mode

### DIFF
--- a/sudokuru/app/Components/Sudoku Board/SudokuBoard.tsx
+++ b/sudokuru/app/Components/Sudoku Board/SudokuBoard.tsx
@@ -136,9 +136,9 @@ const styles = (cellSize, sizeConst) => StyleSheet.create({
     flexWrap: 'wrap',
   },
   actionControlRow: {
-    width: cellSize ? cellSize * 11 : fallbackHeight * 11,
+    width: cellSize ? cellSize * 8 : fallbackHeight * 8,
     height: cellSize ? cellSize: fallbackHeight,
-    justifyContent: 'space-evenly',
+    justifyContent: 'space-between',
     alignItems: 'center',
     flexDirection: 'row',
     marginBottom: cellSize ? cellSize * (1 / 4): fallbackHeight * (1 / 4),
@@ -860,10 +860,13 @@ const HintSection = (props) => {
 
 /*
  * This function retrieves the user's device size and calculates the cell size
+ * board has width and height dimensions of 1 x 1.44444
  */
-function getCellSize() {
-    const size = useWindowDimensions();
-    return Math.min(size.width, size.height) / 15;
+function getCellSize()
+{
+  const size = useWindowDimensions();
+  
+  return Math.min(size.width * 1.44444, size.height) / 15;
 }
 
 function updateBoardWithNumber({ x, y, number, fill = true, board }) {
@@ -1614,7 +1617,7 @@ export default class SudokuBoard extends React.Component<any, any, any, any, any
     inHintMode = board ? board.get('inHintMode') : false;
 
     return (
-      <View onKeyDown={this.handleKeyDown}>
+      <View onKeyDown={this.handleKeyDown} styles={{borderWidth: 1}}>
         {board && !this.props.isDrill && this.renderTopBar()}
         {board && this.renderPuzzle()}
         {board &&

--- a/sudokuru/app/Components/Sudoku Board/SudokuBoard.tsx
+++ b/sudokuru/app/Components/Sudoku Board/SudokuBoard.tsx
@@ -980,6 +980,12 @@ export default class SudokuBoard extends React.Component<any, any, any, any, any
 
     if (!hint) return;
     print("hint:", hint)
+    const words = hint.strategy.toLowerCase().replaceAll('_', ' ').split(" ");
+    for (let i = 0; i < words.length; i++)
+      words[i] = words[i][0].toUpperCase() + words[i].substr(1);
+    stratName = words.join(" ");
+    print("stratName:", stratName);
+    board = board.set('hintStratName', stratName);
 
     let causes = []
     let groups = []
@@ -1530,7 +1536,7 @@ export default class SudokuBoard extends React.Component<any, any, any, any, any
         {board &&
           <View style={styles().bottomActions}>
             {this.renderActions()}
-            {this.renderNumberControl()}
+            {!inHintMode && this.renderNumberControl()}
             {this.props.isDrill && !inHintMode && this.renderSubmitButton()}
           </View>
         }

--- a/sudokuru/app/Components/Sudoku Board/SudokuBoard.tsx
+++ b/sudokuru/app/Components/Sudoku Board/SudokuBoard.tsx
@@ -984,8 +984,11 @@ export default class SudokuBoard extends React.Component<any, any, any, any, any
     for (let i = 0; i < words.length; i++)
       words[i] = words[i][0].toUpperCase() + words[i].substr(1);
     hintStratName = words.join(" ");
-    print("hintStratName:", hintStratName);
     board = board.set('hintStratName', hintStratName);
+    const hintInfo = hint.info;
+    board = board.set('hintInfo', hintInfo);
+    const hintAction = hint.action;
+    board = board.set('hintAction', hintAction);
 
     let causes = []
     let groups = []
@@ -1529,7 +1532,10 @@ export default class SudokuBoard extends React.Component<any, any, any, any, any
     drillMode = this.props.isDrill;
     inHintMode = board ? board.get('inHintMode') : false;
     hintStratName = board ? board.get('hintStratName') : "Hint";
-    console.log("woo in render, hintStratName: " + hintStratName);
+    currentStep = board ? board.get('currentStep') : -1;
+    hintInfo = board ? board.get('hintInfo') : "Info";
+    hintAction = board ? board.get('hintAction') : "Action";
+    console.log(currentStep >= 0 && "hintStratName: " + hintStratName + (currentStep == 0 ? " hintInfo: " + hintInfo : " hintAction: " + hintAction));
 
     return (
       <View onKeyDown={this.handleKeyDown}>

--- a/sudokuru/app/Components/Sudoku Board/SudokuBoard.tsx
+++ b/sudokuru/app/Components/Sudoku Board/SudokuBoard.tsx
@@ -220,7 +220,7 @@ const styles = (cellSize, sizeConst) => StyleSheet.create({
     flexDirection: 'column',
     justifyContent: 'center',
     alignItems: 'center',
-    width: cellSize ? cellSize * 7 : fallbackHeight * 7,
+    width: cellSize ? cellSize * 5 : fallbackHeight * 5,
   },
   hintStratNameView: {
 

--- a/sudokuru/app/Components/Sudoku Board/SudokuBoard.tsx
+++ b/sudokuru/app/Components/Sudoku Board/SudokuBoard.tsx
@@ -1521,6 +1521,7 @@ export default class SudokuBoard extends React.Component<any, any, any, any, any
     }
     
     drillMode = this.props.isDrill;
+    inHintMode = board ? board.get('inHintMode') : false;
 
     return (
       <View onKeyDown={this.handleKeyDown}>
@@ -1530,7 +1531,7 @@ export default class SudokuBoard extends React.Component<any, any, any, any, any
           <View style={styles().bottomActions}>
             {this.renderActions()}
             {this.renderNumberControl()}
-            {this.props.isDrill && this.renderSubmitButton()}
+            {this.props.isDrill && !inHintMode && this.renderSubmitButton()}
           </View>
         }
       </View>

--- a/sudokuru/app/Components/Sudoku Board/SudokuBoard.tsx
+++ b/sudokuru/app/Components/Sudoku Board/SudokuBoard.tsx
@@ -285,35 +285,11 @@ NumberControl.defaultProps = {
 };
 
 const Puzzle = (props) => {
-  const { board, inHintMode, renderCell, rightArrowClicked, leftArrowClicked, checkMarkClicked, onFirstStep, onFinalStep } = props;
+  const { board, renderCell } = props;
   const cellSize = getCellSize();
-  const sizeConst = (Platform.OS == 'web') ? 1.5 : 1;
-
-  const isRightArrowRendered = (inHintMode, onFinalStep) =>
-  {
-    return false //inHintMode && !onFinalStep;
-  }
-
-  const isLeftArrowRendered = (inHintMode, onFirstStep) =>
-  {
-    return false //inHintMode && !onFirstStep;
-  }
-
-  const isCheckMarkRendered = (inHintMode, onFinalStep) =>
-  {
-    return false //inHintMode && onFinalStep;
-  }
 
   return (
     <View style={styles(cellSize).hintAndPuzzleContainer}>
-      {/* {(isLeftArrowRendered(inHintMode, onFirstStep))
-        ? // checkcircleo
-        <Pressable onPress={leftArrowClicked}>
-          <AntDesign color="white" name="leftcircleo" size={cellSize/(sizeConst)}/>
-        </Pressable>
-        :
-        <View style={styles(cellSize, sizeConst).hintArrowPlaceholderView}></View>
-      } */}
       <View style={styles().boardContainer}>
         {board.get('puzzle').map((row, i) => (
           <View key={i} style={styles().rowContainer}>
@@ -321,20 +297,6 @@ const Puzzle = (props) => {
           </View>
         )).toArray()}
       </View>
-      {/* {(isRightArrowRendered(inHintMode, onFinalStep))
-        ?
-        <Pressable onPress={rightArrowClicked}>
-          <AntDesign color="white" name="rightcircleo" size={cellSize/(sizeConst)}/>
-        </Pressable>
-        :
-        (isCheckMarkRendered(inHintMode, onFinalStep))
-          ?
-          <Pressable onPress={checkMarkClicked}>
-            <AntDesign color="white" name="checkcircle" size={cellSize/(sizeConst)}/>
-          </Pressable>
-          :
-          <View style={styles(cellSize, sizeConst).hintArrowPlaceholderView}></View>
-      } */}
     </View>
   );
 }

--- a/sudokuru/app/Components/Sudoku Board/SudokuBoard.tsx
+++ b/sudokuru/app/Components/Sudoku Board/SudokuBoard.tsx
@@ -137,11 +137,11 @@ const styles = (cellSize, sizeConst) => StyleSheet.create({
   },
   actionControlRow: {
     width: cellSize ? cellSize * 11 : fallbackHeight * 11,
-    height: cellSize ? cellSize * 1.5: fallbackHeight * (3 / 4),
+    height: cellSize ? cellSize: fallbackHeight,
     justifyContent: 'space-evenly',
     alignItems: 'center',
     flexDirection: 'row',
-    marginBottom: cellSize ? cellSize * (1 / 2): fallbackHeight * (1 / 2),
+    marginBottom: cellSize ? cellSize * (1 / 4): fallbackHeight * (1 / 4),
   },
   actionControlButton: {
     height: cellSize ? cellSize * (0.5) : 1000,
@@ -979,6 +979,7 @@ export default class SudokuBoard extends React.Component<any, any, any, any, any
     let hint = solution ? this.props.getHint(board, solution) : this.props.getHint(board);
 
     if (!hint) return;
+    print("hint:", hint)
 
     let causes = []
     let groups = []

--- a/sudokuru/app/Components/Sudoku Board/SudokuBoard.tsx
+++ b/sudokuru/app/Components/Sudoku Board/SudokuBoard.tsx
@@ -38,7 +38,7 @@ const styles = (cellSize, sizeConst) => StyleSheet.create({
   hardLineThickness : {thickness: cellSize * (3 / 40)},
   hintArrowPlaceholderView: {
     width: cellSize/(sizeConst),
-    height: cellSize/(sizeConst)
+    height: cellSize/(sizeConst),
   },
   hintAndPuzzleContainer: {
     justifyContent: "space-evenly",
@@ -205,6 +205,38 @@ const styles = (cellSize, sizeConst) => StyleSheet.create({
     fontFamily: 'Inter_700Bold',
     fontSize: cellSize ? cellSize * (1 / 3) + 1 : fallbackHeight * (1 / 3) + 1,
     color: '#FFFFFF',
+  },
+  hintSectionContainer: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    width: cellSize ? cellSize * 9 : fallbackHeight * 9,
+  },
+  hintTextContainer: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+    width: cellSize ? cellSize * 7 : fallbackHeight * 7,
+  },
+  hintStratNameView: {
+
+  },
+  hintStratNameText: {
+    fontFamily: 'Inter_700Bold',
+    fontSize: cellSize ? cellSize * (1 / 2) : fallbackHeight * (1 / 2) ,
+    color: gold,
+  },
+  hintActionInfoView: {
+
+  },
+  hintActionInfoText: {
+    fontSize: cellSize ? cellSize * (1 / 4) : fallbackHeight * (1 / 4),
+    color: "white",
+    textAlign: 'center',
   }
 });
 
@@ -259,29 +291,29 @@ const Puzzle = (props) => {
 
   const isRightArrowRendered = (inHintMode, onFinalStep) =>
   {
-    return inHintMode && !onFinalStep;
+    return false //inHintMode && !onFinalStep;
   }
 
   const isLeftArrowRendered = (inHintMode, onFirstStep) =>
   {
-    return inHintMode && !onFirstStep;
+    return false //inHintMode && !onFirstStep;
   }
 
   const isCheckMarkRendered = (inHintMode, onFinalStep) =>
   {
-    return inHintMode && onFinalStep;
+    return false //inHintMode && onFinalStep;
   }
 
   return (
     <View style={styles(cellSize).hintAndPuzzleContainer}>
-      {(isLeftArrowRendered(inHintMode, onFirstStep))
+      {/* {(isLeftArrowRendered(inHintMode, onFirstStep))
         ? // checkcircleo
         <Pressable onPress={leftArrowClicked}>
           <AntDesign color="white" name="leftcircleo" size={cellSize/(sizeConst)}/>
         </Pressable>
         :
         <View style={styles(cellSize, sizeConst).hintArrowPlaceholderView}></View>
-      }
+      } */}
       <View style={styles().boardContainer}>
         {board.get('puzzle').map((row, i) => (
           <View key={i} style={styles().rowContainer}>
@@ -289,7 +321,7 @@ const Puzzle = (props) => {
           </View>
         )).toArray()}
       </View>
-      {(isRightArrowRendered(inHintMode, onFinalStep))
+      {/* {(isRightArrowRendered(inHintMode, onFinalStep))
         ?
         <Pressable onPress={rightArrowClicked}>
           <AntDesign color="white" name="rightcircleo" size={cellSize/(sizeConst)}/>
@@ -302,7 +334,7 @@ const Puzzle = (props) => {
           </Pressable>
           :
           <View style={styles(cellSize, sizeConst).hintArrowPlaceholderView}></View>
-      }
+      } */}
     </View>
   );
 }
@@ -806,6 +838,62 @@ HeaderRow.propTypes = {
 
 HeaderRow.defaultProps = {
     paused: false,
+}
+
+const HintSection = (props) => {
+  const { hintStratName, hintInfo, hintAction, currentStep, rightArrowClicked, leftArrowClicked, checkMarkClicked, onFirstStep, onFinalStep } = props;
+  const cellSize = getCellSize();
+  const sizeConst = (Platform.OS == 'web') ? 1.5 : 1;
+  
+  const isRightArrowRendered = (onFinalStep) =>
+  {
+    return !onFinalStep;
+  }
+
+  const isLeftArrowRendered = (onFirstStep) =>
+  {
+    return !onFirstStep;
+  }
+
+  const isCheckMarkRendered = (onFinalStep) =>
+  {
+    return onFinalStep;
+  }
+
+  return (
+    <View style={styles(cellSize).hintSectionContainer}>
+      {(isLeftArrowRendered(onFirstStep))
+        ? // checkcircleo
+        <Pressable onPress={leftArrowClicked}>
+          <AntDesign color="white" name="leftcircleo" size={cellSize/(sizeConst)}/>
+        </Pressable>
+        :
+        <View style={styles(cellSize, sizeConst).hintArrowPlaceholderView}></View>
+      }
+      <View style={styles(cellSize).hintTextContainer}>
+        <View style={styles(cellSize).hintStratNameView}>
+          <Text style={styles(cellSize).hintStratNameText}>{hintStratName}</Text>
+        </View>
+        <View style={styles(cellSize).hintActionInfoView}>
+          <Text style={styles(cellSize).hintActionInfoText}>{currentStep == 0 ? hintInfo : hintAction}</Text>
+        </View>
+      </View>
+      {(isRightArrowRendered(onFinalStep))
+        ?
+        <Pressable onPress={rightArrowClicked}>
+          <AntDesign color="white" name="rightcircleo" size={cellSize/(sizeConst)}/>
+        </Pressable>
+        :
+        (isCheckMarkRendered(onFinalStep))
+          ?
+          <Pressable onPress={checkMarkClicked}>
+            <AntDesign color="white" name="checkcircle" size={cellSize/(sizeConst)}/>
+          </Pressable>
+          :
+          <View style={styles(cellSize, sizeConst).hintArrowPlaceholderView}></View>
+      }
+    </View>
+  );
 }
 
 /*
@@ -1516,6 +1604,37 @@ export default class SudokuBoard extends React.Component<any, any, any, any, any
     );
   }
 
+  renderHintSection = () => {
+    const { board } = this.state;
+    let onFirstStep = false;
+    let onFinalStep = false;
+    if (board.get('hintSteps') != undefined)
+    {
+      let currentStep = board.get('currentStep');
+      let numHintSteps = board.get('hintSteps').length;
+      if (currentStep + 1 == 1) onFirstStep = true;
+      if (currentStep + 1 == numHintSteps) onFinalStep = true;
+    }
+    hintStratName = board ? board.get('hintStratName') : "Hint";
+    currentStep = board ? board.get('currentStep') : -1;
+    hintInfo = board ? board.get('hintInfo') : "Info";
+    hintAction = board ? board.get('hintAction') : "Action";
+    console.log(currentStep >= 0 && "hintStratName: " + hintStratName + (currentStep == 0 ? " hintInfo: " + hintInfo : " hintAction: " + hintAction));
+    return(
+      <HintSection
+        hintStratName={ hintStratName }
+        hintInfo={ hintInfo }
+        hintAction={ hintAction }
+        currentStep={ currentStep }
+        rightArrowClicked = { this.rightArrowClicked }
+        leftArrowClicked = { this.leftArrowClicked }
+        checkMarkClicked = { this.checkMarkClicked }
+        onFirstStep = { onFirstStep }
+        onFinalStep = { onFinalStep }
+      />
+    );
+  }
+
   componentDidMount() {
     if (!this.state.board) {
       this.props.generatedGame.then(game => this.setState(game));
@@ -1531,11 +1650,6 @@ export default class SudokuBoard extends React.Component<any, any, any, any, any
     
     drillMode = this.props.isDrill;
     inHintMode = board ? board.get('inHintMode') : false;
-    hintStratName = board ? board.get('hintStratName') : "Hint";
-    currentStep = board ? board.get('currentStep') : -1;
-    hintInfo = board ? board.get('hintInfo') : "Info";
-    hintAction = board ? board.get('hintAction') : "Action";
-    console.log(currentStep >= 0 && "hintStratName: " + hintStratName + (currentStep == 0 ? " hintInfo: " + hintInfo : " hintAction: " + hintAction));
 
     return (
       <View onKeyDown={this.handleKeyDown}>
@@ -1546,6 +1660,7 @@ export default class SudokuBoard extends React.Component<any, any, any, any, any
             {this.renderActions()}
             {!inHintMode && this.renderNumberControl()}
             {this.props.isDrill && !inHintMode && this.renderSubmitButton()}
+            {inHintMode && this.renderHintSection()}
           </View>
         }
       </View>

--- a/sudokuru/app/Components/Sudoku Board/SudokuBoard.tsx
+++ b/sudokuru/app/Components/Sudoku Board/SudokuBoard.tsx
@@ -983,9 +983,9 @@ export default class SudokuBoard extends React.Component<any, any, any, any, any
     const words = hint.strategy.toLowerCase().replaceAll('_', ' ').split(" ");
     for (let i = 0; i < words.length; i++)
       words[i] = words[i][0].toUpperCase() + words[i].substr(1);
-    stratName = words.join(" ");
-    print("stratName:", stratName);
-    board = board.set('hintStratName', stratName);
+    hintStratName = words.join(" ");
+    print("hintStratName:", hintStratName);
+    board = board.set('hintStratName', hintStratName);
 
     let causes = []
     let groups = []
@@ -1528,6 +1528,8 @@ export default class SudokuBoard extends React.Component<any, any, any, any, any
     
     drillMode = this.props.isDrill;
     inHintMode = board ? board.get('inHintMode') : false;
+    hintStratName = board ? board.get('hintStratName') : "Hint";
+    console.log("woo in render, hintStratName: " + hintStratName);
 
     return (
       <View onKeyDown={this.handleKeyDown}>

--- a/sudokuru/app/Pages/DrillPage.tsx
+++ b/sudokuru/app/Pages/DrillPage.tsx
@@ -175,12 +175,11 @@ const DrillPage = (props) => {
       let originalBoard = makeBoard(strPuzzleToArray(game.puzzleCurrentState), game.puzzleCurrentState);
       originalBoard = parseApiAndAddNotes(originalBoard, game.puzzleCurrentNotesState, true);
       let puzzleSolution = game.puzzleSolution;
+      console.log(puzzleSolution)
       return { board, originalBoard, puzzleSolution };
     });
 
     let drillSolutionCells = getDrillSolutionCells(board);
-
-    console.log()
 
     return {
       board, history: List.of(board), historyOffSet: 0, drillSolutionCells, originalBoard, solution: puzzleSolution


### PR DESCRIPTION
Changelog:
- Moving hint arrows from side of board to bottom of screen
- Adding Hint type and hint description when in Hint mode
fixes #147 

## Checklist for completing pull request:
- [ ] Test functionality on Android and web (iOS optional but encouraged)
- [ ] Verify that any unit tests for new functionality are created and functional.
- [ ] If needed, update the Readme