### PR TITLE
Adding lesson tracking

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -34,7 +34,7 @@ jobs:
         working-directory: ./sudokuru
 
       - name: 🚀 Publish App preview
-        run: USERACTIVEGAMESBFFURL=${{ secrets.DEV_USERACTIVEGAMESBFFURL }} DOMAIN=${{ secrets.DEV_DOMAIN }} CLIENT_ID=${{ secrets.DEV_CLIENT_ID }} AUDIENCE=${{ secrets.DEV_AUDIENCE }} SCOPE=${{ secrets.DEV_SCOPE }} expo publish --release-channel=pr-${{ github.event.number }} --non-interactive
+        run: USERGAMESTATISTICSBFFURL=${{ secrets.DEV_USERGAMESTATISTICSBFFURL }} USERACTIVEGAMESBFFURL=${{ secrets.DEV_USERACTIVEGAMESBFFURL }} DOMAIN=${{ secrets.DEV_DOMAIN }} CLIENT_ID=${{ secrets.DEV_CLIENT_ID }} AUDIENCE=${{ secrets.DEV_AUDIENCE }} SCOPE=${{ secrets.DEV_SCOPE }} expo publish --release-channel=pr-${{ github.event.number }} --non-interactive
         working-directory: ./sudokuru
 
       - name: Publish Website Preview
@@ -74,7 +74,7 @@ jobs:
         working-directory: ./sudokuru
 
       - name: 🚀 Build app
-        run: USERACTIVEGAMESBFFURL=${{ secrets.DEV_USERACTIVEGAMESBFFURL }} DOMAIN=${{ secrets.DEV_DOMAIN }} CLIENT_ID=${{ secrets.DEV_CLIENT_ID }} AUDIENCE=${{ secrets.DEV_AUDIENCE }} SCOPE=${{ secrets.DEV_SCOPE }} eas build --non-interactive --platform android --local
+        run: USERGAMESTATISTICSBFFURL=${{ secrets.DEV_USERGAMESTATISTICSBFFURL }} USERACTIVEGAMESBFFURL=${{ secrets.DEV_USERACTIVEGAMESBFFURL }} DOMAIN=${{ secrets.DEV_DOMAIN }} CLIENT_ID=${{ secrets.DEV_CLIENT_ID }} AUDIENCE=${{ secrets.DEV_AUDIENCE }} SCOPE=${{ secrets.DEV_SCOPE }} eas build --non-interactive --platform android --local
         working-directory: ./sudokuru
         env:
           EAS_LOCAL_BUILD_ARTIFACTS_DIR: Build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,15 @@
 version: '3.8'
 
 services:
+  user_game_statistics_bff_app:
+    container_name: user_game_statistics_bff_app
+    image: ghcr.io/sudokuru/usergamestatisticsbff:latest
+    restart: unless-stopped
+    command: npm run start
+    ports:
+      - "2902:2902"
+    links:
+      - user_game_statistics_app
   user_active_games_bff_app:
     container_name: user_active_games_bff_app
     image: ghcr.io/sudokuru/useractivegamesbff:latest

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "docker:start": "npm run docker:pull && docker-compose up -d",
-    "docker:pull": "docker pull ghcr.io/sudokuru/useractivegamesbff && docker pull ghcr.io/sudokuru/puzzle && docker pull ghcr.io/sudokuru/useractivegames",
+    "docker:pull": "docker pull ghcr.io/sudokuru/usergamestatisticsbff && docker pull ghcr.io/sudokuru/useractivegamesbff && docker pull ghcr.io/sudokuru/puzzle && docker pull ghcr.io/sudokuru/useractivegames",
     "docker:imageVersions": "docker images"
   },
   "private": true

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "docker:start": "npm run docker:pull && docker-compose up -d",
-    "docker:pull": "docker pull ghcr.io/sudokuru/usergamestatisticsbff && docker pull ghcr.io/sudokuru/useractivegamesbff && docker pull ghcr.io/sudokuru/puzzle && docker pull ghcr.io/sudokuru/useractivegames",
+    "docker:pull": "docker pull ghcr.io/sudokuru/usergamestatisticsbff && docker pull ghcr.io/sudokuru/useractivegamesbff && docker pull ghcr.io/sudokuru/usergamestatistics && docker pull ghcr.io/sudokuru/puzzle && docker pull ghcr.io/sudokuru/useractivegames",
     "docker:imageVersions": "docker images"
   },
   "private": true

--- a/sudokuru/.env.template
+++ b/sudokuru/.env.template
@@ -6,3 +6,4 @@ CLIENT_ID=get_value_from_MSB_building
 AUDIENCE=get_value_from_MSB_building
 SCOPE=get_value_from_MSB_building
 USERACTIVEGAMESBFFURL=http://localhost:2901/
+USERGAMESTATISTICSBFFURL=http://localhost:2902/

--- a/sudokuru/App.tsx
+++ b/sudokuru/App.tsx
@@ -70,12 +70,10 @@ export default function App() {
     let theme = isThemeDark ? CombinedDarkTheme : CombinedDefaultTheme;
 
     const toggleTheme = React.useCallback(() => {
-        console.log(isThemeDark)
         return setIsThemeDark(!isThemeDark);
     }, [isThemeDark]);
 
     const updateLearnedLessons = React.useCallback((props: any) => {
-        console.log(learnedLessons)
         return setLearnedLessons(props);
     }, [learnedLessons]);
 

--- a/sudokuru/App.tsx
+++ b/sudokuru/App.tsx
@@ -69,7 +69,7 @@ function HomeDrawer(){
 export default function App() {
 
     const [isThemeDark, setIsThemeDark] = React.useState(true);
-    const [learnedLessons, setLearnedLessons] = React.useState([]);
+    const [learnedLessons, setLearnedLessons] = React.useState<string[]>(["Banana"]);
 
     let theme = isThemeDark ? CombinedDarkTheme : CombinedDefaultTheme;
 

--- a/sudokuru/App.tsx
+++ b/sudokuru/App.tsx
@@ -40,18 +40,14 @@ const drawerItemsMain = [
         {nav: 'Home', routeName: 'Hidden Quadruplet', title: 'Hidden Quadruplet'},
       ],
   },
-  // {
-  //     key: 'Pointing Pair',
-  //     title: 'Pointing Pair',
-  //     routes: [{nav: 'Home', routeName: 'Pointing Pair', title: 'Pointing Pair'}],
-  // },
 ];
 
 function HomeDrawer(){
     const Drawer = createDrawerNavigator();
 
     return(
-     <Drawer.Navigator initialRouteName="Home" drawerContent={(props) => (<CustomDrawerContent drawerItems={drawerItemsMain} {...props} />)}
+     <Drawer.Navigator initialRouteName="Home" drawerContent={(props) => (<CustomDrawerContent
+         drawerItems={drawerItemsMain} {...props} />)}
       screenOptions={{headerShown:false, headerTransparent:true, swipeEdgeWidth: 0, drawerPosition: "left", unmountOnBlur:true}}>
           <Drawer.Screen name="Main Page" component={HomePage} />
           <Drawer.Screen name="Naked Single" initialParams={{ params: ["NAKED_SINGLE"] }} component={DrillPage} />

--- a/sudokuru/App.tsx
+++ b/sudokuru/App.tsx
@@ -69,7 +69,7 @@ function HomeDrawer(){
 export default function App() {
 
     const [isThemeDark, setIsThemeDark] = React.useState(true);
-    const [learnedLessons, setLearnedLessons] = React.useState<string[]>(["Banana"]);
+    const [learnedLessons, setLearnedLessons] = React.useState<string[]>([]);
 
     let theme = isThemeDark ? CombinedDarkTheme : CombinedDefaultTheme;
 

--- a/sudokuru/App.tsx
+++ b/sudokuru/App.tsx
@@ -17,6 +17,7 @@ import {CombinedDarkTheme, CombinedDefaultTheme} from './app/Styling/ThemeColors
 import Lesson from "./app/Pages/Lesson";
 import DrillPage from './app/Pages/DrillPage';
 import CustomDrawerContent from './app/Components/Home/CustomDrawerContent';
+import {useEffect} from "react";
 
 const drawerItemsMain = [
   {
@@ -68,19 +69,28 @@ function HomeDrawer(){
 export default function App() {
 
     const [isThemeDark, setIsThemeDark] = React.useState(true);
+    const [learnedLessons, setLearnedLessons] = React.useState([]);
 
     let theme = isThemeDark ? CombinedDarkTheme : CombinedDefaultTheme;
 
     const toggleTheme = React.useCallback(() => {
+        console.log(isThemeDark)
         return setIsThemeDark(!isThemeDark);
     }, [isThemeDark]);
+
+    const updateLearnedLessons = React.useCallback((props: any) => {
+        console.log(learnedLessons)
+        return setLearnedLessons(props);
+    }, [learnedLessons]);
 
     const preferences = React.useMemo(
         () => ({
             toggleTheme,
             isThemeDark,
+            updateLearnedLessons,
+            learnedLessons,
         }),
-        [toggleTheme, isThemeDark]
+        [toggleTheme, isThemeDark, updateLearnedLessons, learnedLessons]
     );
 
     const Stack = createStackNavigator();

--- a/sudokuru/app/Components/Header.tsx
+++ b/sudokuru/app/Components/Header.tsx
@@ -23,7 +23,7 @@ const Header = (props: any) => {
                         height: 45,
                         width: 100,
                     }} source={require('./goldLogoText.png')} />
-                     : <Pressable  onPress={() => navigation.navigate('Main Page')} >
+                     : <Pressable  onPress={() => navigation.navigate('Home')} >
                     <Image style={{
                         resizeMode: 'cover',
                         height: 45,

--- a/sudokuru/app/Components/Header.tsx
+++ b/sudokuru/app/Components/Header.tsx
@@ -23,7 +23,7 @@ const Header = (props: any) => {
                         height: 45,
                         width: 100,
                     }} source={require('./goldLogoText.png')} />
-                     : <Pressable  onPress={() => navigation.navigate('Home')} >
+                     : <Pressable  onPress={() => navigation.navigate('Main Page')} >
                     <Image style={{
                         resizeMode: 'cover',
                         height: 45,

--- a/sudokuru/app/Components/Home/Carousel.tsx
+++ b/sudokuru/app/Components/Home/Carousel.tsx
@@ -35,20 +35,20 @@ const Ccarousel = () => {
     const carouselTextSize: any = isWeb ? { fontSize: 30 } : { fontSize: 20 };
 
     function navigate(index: number):any {
-        index == 0 ? navigation.navigate('Lesson',{params:'AMEND_NOTES'}) :
-            index == 1 ? navigation.navigate('Lesson',{params:'NAKED_SINGLE'}) :
-                    index == 2 ? navigation.navigate('Lesson',{params:'NAKED_SET'}) :
-                        index == 3 ? navigation.navigate('Lesson',{params:'HIDDEN_SINGLE'}) :
-                            index == 4 ? navigation.navigate('Lesson',{params:'HIDDEN_SET'}) : navigation.navigate('Home');
+        index == 0 ? navigation.navigate('Lesson',{params:'SUDOKU_101'}) :
+            index == 1 ? navigation.navigate('Lesson',{params:'AMEND_NOTES'}) :
+                    index == 2 ? navigation.navigate('Lesson',{params:'NAKED_SINGLE'}) :
+                        index == 3 ? navigation.navigate('Lesson',{params:'SIMPLIFY_NOTES'}) :
+                            index == 4 ? navigation.navigate('Lesson',{params:'HIDDEN_SINGLE'}) : navigation.navigate('Home');
     }
 
     function getLessonName(index: number):string {
         let lessonName: string;
-        index == 0 ? lessonName = 'Amend Notes' :
-            index == 1 ? lessonName = 'Naked Single' :
-                index == 2 ? lessonName = 'Naked Set' :
-                    index == 3 ? lessonName = 'Hidden Single' :
-                        index == 4 ? lessonName = 'Hidden Set' : lessonName = 'Null';
+        index == 0 ? lessonName = 'Sudoku 101' :
+            index == 1 ? lessonName = 'Amend Notes' :
+                index == 2 ? lessonName = 'Naked Single' :
+                    index == 3 ? lessonName = 'Simplify Notes' :
+                        index == 4 ? lessonName = 'Hidden Single' : lessonName = 'Null';
         return lessonName;
     }
 

--- a/sudokuru/app/Components/Home/CustomDrawerContent.tsx
+++ b/sudokuru/app/Components/Home/CustomDrawerContent.tsx
@@ -8,6 +8,7 @@ import {
   SafeAreaView,
   Image,
 } from "react-native";
+import {PreferencesContext} from "../../Contexts/PreferencesContext";
 
 function CustomDrawerContent(props) {
   const [mainDrawer, setMainDrawer] = useState(true);
@@ -35,6 +36,9 @@ function CustomDrawerContent(props) {
   };
 
   function renderMainDrawer() {
+
+    const { updateLearnedLessons, learnedLessons } = React.useContext(PreferencesContext);
+
     return (
       <View>
         {props.drawerItems.map((parent) => (
@@ -45,9 +49,13 @@ function CustomDrawerContent(props) {
               onPress={() => {
                 onItemParentPress(parent.key);
               }}>
-              <View style={styles.parentItem}>
-                <Text style={[styles.icon, styles.title]}>{parent.title}</Text>
-              </View>
+              {
+                // Conditionally render Drill navigation depending on lessons the user has completed.
+                ((learnedLessons.includes("NAKED_SINGLE") && parent.title == "Naked Sets") || (learnedLessons.includes("HIDDEN_SINGLE") && parent.title == "Hidden Sets"))
+                  ? <View style={styles.parentItem}>
+                      <Text style={[styles.icon, styles.title]}>{parent.title}</Text>
+                    </View> : <></>
+              }
             </TouchableOpacity>
           </View>
         ))}
@@ -56,6 +64,9 @@ function CustomDrawerContent(props) {
   }
 
   function renderFilteredItemsDrawer() {
+
+    const { updateLearnedLessons, learnedLessons } = React.useContext(PreferencesContext);
+
     return (
       <View>
         <TouchableOpacity
@@ -74,7 +85,15 @@ function CustomDrawerContent(props) {
                 })
               }
               style={styles.item}>
-              <Text style={styles.title}>{route.title}</Text>
+
+              {
+                // Conditionally render Drill navigation depending on lessons the user has completed.
+                ((learnedLessons.includes("NAKED_SINGLE") && route.title == "Naked Single") ||
+                    (learnedLessons.includes("HIDDEN_SINGLE") && route.title == "Hidden Single") ||
+                    (learnedLessons.includes("HIDDEN_SET") && (route.title == "Hidden Pair" || route.title == "Hidden Triplet" || route.title == "Hidden Quadruplet")) ||
+                        (learnedLessons.includes("NAKED_SET") && (route.title == "Naked Pair" || route.title == "Naked Triplet" || route.title == "Naked Quadruplet")))
+                            ? <Text style={styles.title}>{route.title}</Text> : <></>
+              }
             </TouchableOpacity>
           );
         })}

--- a/sudokuru/app/Components/Profile/ThemeToggle.tsx
+++ b/sudokuru/app/Components/Profile/ThemeToggle.tsx
@@ -7,6 +7,8 @@ const ThemeToggle = () => {
     const theme = useTheme();
     const { toggleTheme, isThemeDark } = React.useContext(PreferencesContext);
 
+    console.log(isThemeDark, "HAHA");
+
     return (
         <View>
             <Text>Theme</Text>

--- a/sudokuru/app/Components/Profile/ThemeToggle.tsx
+++ b/sudokuru/app/Components/Profile/ThemeToggle.tsx
@@ -1,13 +1,10 @@
 import React from 'react';
 import { View } from 'react-native';
-import { useTheme, Switch, Text } from 'react-native-paper';
+import { Switch, Text } from 'react-native-paper';
 import { PreferencesContext } from '../../Contexts/PreferencesContext';
 
 const ThemeToggle = () => {
-    const theme = useTheme();
     const { toggleTheme, isThemeDark } = React.useContext(PreferencesContext);
-
-    console.log(isThemeDark, "HAHA");
 
     return (
         <View>

--- a/sudokuru/app/Contexts/PreferencesContext.ts
+++ b/sudokuru/app/Contexts/PreferencesContext.ts
@@ -3,4 +3,6 @@ import React from 'react';
 export const PreferencesContext = React.createContext({
     toggleTheme: () => {},
     isThemeDark: false,
+    updateLearnedLessons: (props: any) => {},
+    learnedLessons: [],
 });

--- a/sudokuru/app/Contexts/PreferencesContext.ts
+++ b/sudokuru/app/Contexts/PreferencesContext.ts
@@ -4,5 +4,5 @@ export const PreferencesContext = React.createContext({
     toggleTheme: () => {},
     isThemeDark: false,
     updateLearnedLessons: (props: any) => {},
-    learnedLessons: [],
+    learnedLessons: [""]
 });

--- a/sudokuru/app/Pages/HomePage.tsx
+++ b/sudokuru/app/Pages/HomePage.tsx
@@ -234,7 +234,7 @@ const HomePage = () => {
                     confirmText={"OK"}
                     confirmButtonColor={theme.colors.background}
                     onConfirmPressed={() => {
-                        hideDoMoreLessons();r
+                        hideDoMoreLessons();
                     }}
                 />
             </SafeAreaView>

--- a/sudokuru/app/Pages/HomePage.tsx
+++ b/sudokuru/app/Pages/HomePage.tsx
@@ -77,8 +77,7 @@ const HomePage = () => {
             // This determines what lessons the user has learned and conditionally displays everything.
             async function getUserLearnedLessons(url: string) {
 
-                // If we have value cached we don't need to get it again
-                console.log("THIS IS IT: ", learnedLessons);
+                // If we have value cached we don't need to get it again (TODO later)
                 let token = null;
                 await getKeyString("access_token").then(result => {
                     token = result;
@@ -86,21 +85,16 @@ const HomePage = () => {
 
                 await Statistics.getLearnedLessons(url, token).then((lessons: any) => {
                     if (lessons !== null) {
-                        console.log(lessons);
-                        console.log(learnedLessons);
                         updateLearnedLessons(lessons.strategiesLearned);
-                        console.log(learnedLessons, "Learned Lessons");
                     }
                     else {
-                        console.log("User has not completed any lessons");
+                        console.log("Error retrieving lessons of user");
                     }
                 });
             }
             grabCurrentGame(USERACTIVEGAMESBFFURL);
             getUserLearnedLessons(USERGAMESTATISTICSBFFURL);
     }, []));
-
-    console.log("GLOBAL", learnedLessons);
 
     let [fontsLoaded] = useFonts({
         Inter_100Thin, Inter_200ExtraLight, Inter_300Light, Inter_400Regular, Inter_500Medium, Inter_700Bold

--- a/sudokuru/app/Pages/HomePage.tsx
+++ b/sudokuru/app/Pages/HomePage.tsx
@@ -78,9 +78,7 @@ const HomePage = () => {
             async function getUserLearnedLessons(url: string) {
 
                 // If we have value cached we don't need to get it again
-                if (!learnedLessons.includes("Banana")){
-                    return;
-                }
+                console.log("THIS IS IT: ", learnedLessons);
                 let token = null;
                 await getKeyString("access_token").then(result => {
                     token = result;

--- a/sudokuru/app/Pages/HomePage.tsx
+++ b/sudokuru/app/Pages/HomePage.tsx
@@ -31,7 +31,7 @@ const HomePage = () => {
     const size = useWindowDimensions();
     const reSize = Math.min(size.width, size.height) / 25;
 
-    const { updateLearnedLessons, learnedLessons, toggleTheme, isThemeDark } = React.useContext(PreferencesContext);
+    const { updateLearnedLessons, learnedLessons } = React.useContext(PreferencesContext);
 
     const [resumeVisible, setResumeVisible] = React.useState(false);
     const showResumeButton = () => setResumeVisible(true);
@@ -76,6 +76,11 @@ const HomePage = () => {
 
             // This determines what lessons the user has learned and conditionally displays everything.
             async function getUserLearnedLessons(url: string) {
+
+                // If we have value cached we don't need to get it again
+                if (!learnedLessons.includes("Banana")){
+                    return;
+                }
                 let token = null;
                 await getKeyString("access_token").then(result => {
                     token = result;
@@ -85,7 +90,7 @@ const HomePage = () => {
                     if (lessons !== null) {
                         console.log(lessons);
                         console.log(learnedLessons);
-                        updateLearnedLessons(lessons);
+                        updateLearnedLessons(lessons.strategiesLearned);
                         console.log(learnedLessons, "Learned Lessons");
                     }
                     else {

--- a/sudokuru/app/Pages/HomePage.tsx
+++ b/sudokuru/app/Pages/HomePage.tsx
@@ -33,6 +33,10 @@ const HomePage = () => {
 
     const { updateLearnedLessons, learnedLessons } = React.useContext(PreferencesContext);
 
+    const [doMoreLessonsVisible, setDoMoreLessonsVisible] = React.useState(false);
+    const showDoMoreLessons = () => setDoMoreLessonsVisible(true);
+    const hideDoMoreLessons = () => setDoMoreLessonsVisible(false);
+
     const [resumeVisible, setResumeVisible] = React.useState(false);
     const showResumeButton = () => setResumeVisible(true);
     const hideResumeButton = () => setResumeVisible(false);
@@ -96,6 +100,12 @@ const HomePage = () => {
             getUserLearnedLessons(USERGAMESTATISTICSBFFURL);
     }, []));
 
+    // returns if user can play game or do drills
+    function canPlay():boolean {
+        return (learnedLessons.includes("SUDOKU_101") && learnedLessons.includes("AMEND_NOTES") &&
+            learnedLessons.includes("NAKED_SINGLE") && learnedLessons.includes("SIMPLIFY_NOTES"));
+    }
+
     let [fontsLoaded] = useFonts({
         Inter_100Thin, Inter_200ExtraLight, Inter_300Light, Inter_400Regular, Inter_500Medium, Inter_700Bold
     });
@@ -130,9 +140,11 @@ const HomePage = () => {
                         </View>
 
                         <View style={{padding: reSize/4}}>
-                            <Button style={{top:reSize/2}} mode="contained" onPress={() => navigation.openDrawer()}>
+                            <Button style={{top:reSize/2}} mode="contained" onPress={() => {
+                                canPlay() ? navigation.openDrawer() : showDoMoreLessons()
+                            }}>
                                 Start Drill
-                            </Button>
+                            </Button>r
                         </View>
 
                         <View style={{top:20, flexDirection: 'row', padding: reSize/4}}>
@@ -157,7 +169,11 @@ const HomePage = () => {
                             }
 
                             <Button mode="contained"
-                                    onPress={() => navigation.navigate('Sudoku', {gameOrigin: "start", difficulty: (difficulty / 100)})}>
+                                    onPress={() => {
+                                        canPlay() ?
+                                        navigation.navigate('Sudoku', {gameOrigin: "start", difficulty: (difficulty / 100)}) :
+                                        showDoMoreLessons();
+                                    }}>
                                 Start Puzzle
                             </Button>
                         </View>
@@ -205,6 +221,20 @@ const HomePage = () => {
                     confirmButtonColor={theme.colors.background}
                     onConfirmPressed={() => {
                         hidePlayHelp();
+                    }}
+                />
+                <Alert
+                    show={doMoreLessonsVisible}
+                    title="Please Complete more lessons!"
+                    message={`To access this feature, please complete more lessons!`}
+                    messageStyle={{maxWidth: 500}}
+                    showConfirmButton={true}
+                    closeOnTouchOutside={false}
+                    closeOnHardwareBackPress={false}
+                    confirmText={"OK"}
+                    confirmButtonColor={theme.colors.background}
+                    onConfirmPressed={() => {
+                        hideDoMoreLessons();r
                     }}
                 />
             </SafeAreaView>

--- a/sudokuru/app/Pages/Lesson.tsx
+++ b/sudokuru/app/Pages/Lesson.tsx
@@ -190,6 +190,21 @@ const Lesson = (props: { route: { params: { params: any; }; }; }) => {
                                         <Text style={{color: theme.colors.onPrimary, textAlign: 'justify', fontSize: size.height/50}}>{steps[count][0]}</Text>
                                         : <></>
                                 }
+
+                                {
+                                    // Button only appears on last page and if lesson has not already been learned
+                                    ((count + 1 == steps.length) && lessonButtonVisible ) ?
+                                        <Button mode="contained" onPress={() => {
+                                            learnedLessons.push(name);
+                                            updateLearnedLessons(learnedLessons);
+                                            setLessonButtonVisible(false);
+                                            saveUserLearnedLessons(USERGAMESTATISTICSBFFURL);
+                                        }}>
+                                            Complete Lesson
+                                        </Button>
+                                        : <></>
+                                }
+
                             </View>
 
                           <Pressable style={{top: reSize/2, height: reSize/8, right: reSize/10}} onPress={() => (count + 1 == steps.length) ? navigation.navigate("Home") :setCount(count + 1)} >

--- a/sudokuru/app/Pages/Lesson.tsx
+++ b/sudokuru/app/Pages/Lesson.tsx
@@ -8,6 +8,9 @@ import {AntDesign, MaterialCommunityIcons} from "@expo/vector-icons";
 import Alert from "react-native-awesome-alerts";
 import {SafeAreaProvider, SafeAreaView} from "react-native-safe-area-context";
 import {useFocusEffect} from "@react-navigation/core";
+import {PreferencesContext} from "../Contexts/PreferencesContext";
+import {getKeyString} from "../Functions/Auth0/token";
+import {USERACTIVEGAMESBFFURL, USERGAMESTATISTICSBFFURL} from "@env";
 
 const sudokuru = require("../../node_modules/sudokuru/dist/bundle.js"); // -- What works for me
 const Lessons = sudokuru.Lessons;
@@ -20,12 +23,16 @@ const Lesson = (props: { route: { params: { params: any; }; }; }) => {
     const size = useWindowDimensions();
     const reSize = Math.min(size.width, size.height);
 
+    const { updateLearnedLessons, learnedLessons } = React.useContext(PreferencesContext);
+
     const [learnHelpVisible, setLearnHelpVisible] = React.useState(false);
     const showLearnHelp = () => setLearnHelpVisible(true);
     const hideLearnHelp = () => setLearnHelpVisible(false);
 
     const [steps, setSteps] = React.useState([]);
     const [isLoading, setIsLoading] = React.useState(true);
+
+    const [lessonButtonVisible, setLessonButtonVisible] = React.useState(false);
 
 
     const theme = useTheme();
@@ -56,12 +63,24 @@ const Lesson = (props: { route: { params: { params: any; }; }; }) => {
             });
         }, []))
 
+    useEffect(() => {
+            // This determines if the "Complete Lesson" button should render
+            // This function should only be called once on page load for initial render
+            if (!learnedLessons.includes(name)) {
+                setLessonButtonVisible(true);
+            } else {
+                setLessonButtonVisible(false);
+            }
+        }, []);
+
       const [count, setCount]  = useState(0);
 
       // Detects the last page of the lesson for sending "complete" status to backend
       if(count + 1 == steps.length){
 
       }
+
+      console.log(learnedLessons);
 
       //Separate view for mobile and web
       const Page = () => {
@@ -100,6 +119,19 @@ const Lesson = (props: { route: { params: { params: any; }; }; }) => {
                       {
                           (steps[count][0] != null) ?
                               <Text style={{color: theme.colors.onPrimary, textAlign: 'justify', fontSize: size.height/50}}>{steps[count][0]}</Text>
+                              : <></>
+                      }
+
+                      {
+                          // Button only appears on last page and if lesson has not already been learned
+                          ((count + 1 == steps.length) && lessonButtonVisible ) ?
+                              <Button mode="contained" onPress={() => {
+                                  learnedLessons.push(name);
+                                  updateLearnedLessons(learnedLessons);
+                                  setLessonButtonVisible(false);
+                              }}>
+                                  Complete Lesson
+                              </Button>
                               : <></>
                       }
                   </View>

--- a/sudokuru/app/Pages/Lesson.tsx
+++ b/sudokuru/app/Pages/Lesson.tsx
@@ -10,7 +10,7 @@ import {SafeAreaProvider, SafeAreaView} from "react-native-safe-area-context";
 import {useFocusEffect} from "@react-navigation/core";
 import {PreferencesContext} from "../Contexts/PreferencesContext";
 import {getKeyString} from "../Functions/Auth0/token";
-import {USERACTIVEGAMESBFFURL, USERGAMESTATISTICSBFFURL} from "@env";
+import {USERGAMESTATISTICSBFFURL} from "@env";
 
 const sudokuru = require("../../node_modules/sudokuru/dist/bundle.js"); // -- What works for me
 const Lessons = sudokuru.Lessons;
@@ -19,6 +19,8 @@ const Statistics = sudokuru.Statistics;
 const Lesson = (props: { route: { params: { params: any; }; }; }) => {
     //Brings in name of strategy from carousel
     let name = props.route.params ? props.route.params.params : "no props.route.params in LessonPage"
+
+    console.log(name);
     const navigation: any = useNavigation();
 
     const size = useWindowDimensions();
@@ -44,7 +46,9 @@ const Lesson = (props: { route: { params: { params: any; }; }; }) => {
             name == "NAKED_SINGLE" ? lessonName = 'Naked Single' :
                 name == "NAKED_SET" ? lessonName = 'Naked Set' :
                     name == "HIDDEN_SINGLE" ? lessonName = 'Hidden Single' :
-                        name == "HIDDEN_SET" ? lessonName = 'Hidden Set' : lessonName = 'Null';
+                        name == "HIDDEN_SET" ? lessonName = 'Hidden Set' :
+                            name == "SUDOKU_101" ? lessonName = 'Sudoku 101' :
+                                name == "SIMPLIFY_NOTES" ? lessonName = 'Simplify Notes' : lessonName = 'Null';
         return lessonName;
     }
 

--- a/sudokuru/app/Pages/Lesson.tsx
+++ b/sudokuru/app/Pages/Lesson.tsx
@@ -76,7 +76,6 @@ const Lesson = (props: { route: { params: { params: any; }; }; }) => {
 
     async function saveUserLearnedLessons(url: string) {
 
-        // If we have value cached we don't need to get it again
         let token = null;
         await getKeyString("access_token").then(result => {
             token = result;

--- a/sudokuru/app/Pages/Lesson.tsx
+++ b/sudokuru/app/Pages/Lesson.tsx
@@ -20,7 +20,6 @@ const Lesson = (props: { route: { params: { params: any; }; }; }) => {
     //Brings in name of strategy from carousel
     let name = props.route.params ? props.route.params.params : "no props.route.params in LessonPage"
 
-    console.log(name);
     const navigation: any = useNavigation();
 
     const size = useWindowDimensions();

--- a/sudokuru/app/Pages/Lesson.tsx
+++ b/sudokuru/app/Pages/Lesson.tsx
@@ -102,8 +102,6 @@ const Lesson = (props: { route: { params: { params: any; }; }; }) => {
 
       }
 
-      console.log(learnedLessons);
-
       //Separate view for mobile and web
       const Page = () => {
           // Wait for page to load the stuff

--- a/sudokuru/app/Pages/Lesson.tsx
+++ b/sudokuru/app/Pages/Lesson.tsx
@@ -14,6 +14,7 @@ import {USERACTIVEGAMESBFFURL, USERGAMESTATISTICSBFFURL} from "@env";
 
 const sudokuru = require("../../node_modules/sudokuru/dist/bundle.js"); // -- What works for me
 const Lessons = sudokuru.Lessons;
+const Statistics = sudokuru.Statistics;
 
 const Lesson = (props: { route: { params: { params: any; }; }; }) => {
     //Brings in name of strategy from carousel
@@ -73,6 +74,28 @@ const Lesson = (props: { route: { params: { params: any; }; }; }) => {
             }
         }, []);
 
+    async function saveUserLearnedLessons(url: string) {
+
+        // If we have value cached we don't need to get it again
+        let token = null;
+        await getKeyString("access_token").then(result => {
+            token = result;
+        });
+
+        let jsonBody = {
+            "strategiesLearned": learnedLessons
+        }
+
+        await Statistics.saveLearnedLessons(url, jsonBody, token).then((res: any) => {
+            if (res) {
+                console.log("Lessons save successfully!")
+            }
+            else {
+                console.log("Lesson not saved");
+            }
+        });
+    }
+
       const [count, setCount]  = useState(0);
 
       // Detects the last page of the lesson for sending "complete" status to backend
@@ -129,6 +152,7 @@ const Lesson = (props: { route: { params: { params: any; }; }; }) => {
                                   learnedLessons.push(name);
                                   updateLearnedLessons(learnedLessons);
                                   setLessonButtonVisible(false);
+                                  saveUserLearnedLessons(USERGAMESTATISTICSBFFURL);
                               }}>
                                   Complete Lesson
                               </Button>

--- a/sudokuru/app/Pages/StatisticsPage.tsx
+++ b/sudokuru/app/Pages/StatisticsPage.tsx
@@ -70,6 +70,7 @@ const StatisticsPage = () => {
       else {
         console.log("Statistics not deleted");
       }
+      updateLearnedLessons([]);
       navigation.navigate("Home");
     });
   }

--- a/sudokuru/app/Pages/StatisticsPage.tsx
+++ b/sudokuru/app/Pages/StatisticsPage.tsx
@@ -46,7 +46,7 @@ const StatisticsPage = () => {
     });
 
     const gameData = await Puzzles.getGame(url, token).then(game => {
-      if (game[0].puzzle == null) {
+      if (game == null) {
         console.log(game);
         return null;
       }

--- a/sudokuru/app/Pages/StatisticsPage.tsx
+++ b/sudokuru/app/Pages/StatisticsPage.tsx
@@ -8,6 +8,7 @@ import { Dimensions, useWindowDimensions } from "react-native";
 import {getKeyString} from "../Functions/Auth0/token";
 import {USERACTIVEGAMESBFFURL} from '@env'
 import {useFocusEffect} from "@react-navigation/core";
+import {PreferencesContext} from "../Contexts/PreferencesContext";
 
 // Sudokuru Package Import
 const sudokuru = require("../../node_modules/sudokuru/dist/bundle.js");
@@ -17,8 +18,6 @@ const Puzzles = sudokuru.Puzzles;
 
 const StatisticsPage = () => {
   const theme = useTheme();
-
-  const screenWidth = Dimensions.get("window").width;
 
   const size = useWindowDimensions();
   const reSize = Math.min(size.width, size.height);
@@ -57,11 +56,20 @@ const StatisticsPage = () => {
     grabCurrentGame(USERACTIVEGAMESBFFURL);
   });
 
+  const { updateLearnedLessons, learnedLessons } = React.useContext(PreferencesContext);
+
   return (
     <SafeAreaProvider>
       <SafeAreaView style={{height: '100%', width: '100%'}}>
         <Header page="Statistics" />
         <View style={{ alignItems: 'center', justifyContent: 'center', marginVertical: 30 }}>
+          <Text style={{ fontSize: reSize/20, color: '#D9A05B', fontWeight: 'bold', marginBottom: 10 }}>Statistics</Text>
+          <View style={{ backgroundColor: '#fff', borderRadius: 10, padding: 20 }}>
+            <View style={{ marginBottom: 10 }}>
+              <Text style={{ fontSize: reSize/22, color: '#025E73'}}>Strategies Learned:</Text>
+              <Text style={{ fontSize: reSize/20, fontWeight: 'bold', color: '#D9A05B' }}>{learnedLessons.join('\r\n')}</Text>
+            </View>
+          </View>
           <Text style={{ fontSize: reSize/20, color: '#D9A05B', fontWeight: 'bold', marginBottom: 10 }}>Game Statistics</Text>
           {activeGame ? (
             <View style={{ backgroundColor: '#fff', borderRadius: 10, padding: 20 }}>

--- a/sudokuru/app/Pages/StatisticsPage.tsx
+++ b/sudokuru/app/Pages/StatisticsPage.tsx
@@ -73,9 +73,10 @@ const StatisticsPage = () => {
     });
   }
 
-  useFocusEffect(() => {
+  useFocusEffect(
+      React.useCallback(() => {
     grabCurrentGame(USERACTIVEGAMESBFFURL);
-  }, []);
+  }, []));
 
   const { updateLearnedLessons, learnedLessons } = React.useContext(PreferencesContext);
 

--- a/sudokuru/app/Pages/StatisticsPage.tsx
+++ b/sudokuru/app/Pages/StatisticsPage.tsx
@@ -1,23 +1,26 @@
 // @ts-nocheck
 import React, { useState, useEffect } from 'react';
 import {StyleSheet, View} from "react-native";
-import {Text, useTheme} from 'react-native-paper';
+import {Button, Text, useTheme} from 'react-native-paper';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 import Header from "../Components/Header"; 
 import { Dimensions, useWindowDimensions } from "react-native";
 import {getKeyString} from "../Functions/Auth0/token";
-import {USERACTIVEGAMESBFFURL} from '@env'
+import {USERACTIVEGAMESBFFURL, USERGAMESTATISTICSBFFURL} from '@env'
 import {useFocusEffect} from "@react-navigation/core";
 import {PreferencesContext} from "../Contexts/PreferencesContext";
+import {useNavigation} from "@react-navigation/native";
 
 // Sudokuru Package Import
 const sudokuru = require("../../node_modules/sudokuru/dist/bundle.js");
 
 // Sudokuru Package Constants
 const Puzzles = sudokuru.Puzzles;
+const Statistics = sudokuru.Statistics;
 
 const StatisticsPage = () => {
   const theme = useTheme();
+  const navigation: any = useNavigation();
 
   const size = useWindowDimensions();
   const reSize = Math.min(size.width, size.height);
@@ -50,6 +53,24 @@ const StatisticsPage = () => {
       return game[0];
     });
     setActiveGame(gameData);
+  }
+
+  async function deleteUserStatistics(url: string) {
+
+    let token = null;
+    await getKeyString("access_token").then(result => {
+      token = result;
+    });
+
+    await Statistics.deleteStatistics(url, token).then((res: any) => {
+      if (res) {
+        console.log("Statistics deleted successfully!")
+      }
+      else {
+        console.log("Statistics not deleted");
+      }
+      navigation.navigate("Home");
+    });
   }
 
   useFocusEffect(() => {
@@ -94,6 +115,11 @@ const StatisticsPage = () => {
             <Text style={{ color: '#fff' }}>No active game found.</Text>
           )}
         </View>
+        <Button mode="contained" onPress={() => {
+          deleteUserStatistics(USERGAMESTATISTICSBFFURL);
+        }}>
+          Delete Statistics
+        </Button>
       </SafeAreaView>
     </SafeAreaProvider>
   );

--- a/sudokuru/app/Pages/StatisticsPage.tsx
+++ b/sudokuru/app/Pages/StatisticsPage.tsx
@@ -47,7 +47,6 @@ const StatisticsPage = () => {
 
     const gameData = await Puzzles.getGame(url, token).then(game => {
       if (game == null) {
-        console.log(game);
         return null;
       }
       return game[0];

--- a/sudokuru/app/Pages/StatisticsPage.tsx
+++ b/sudokuru/app/Pages/StatisticsPage.tsx
@@ -27,6 +27,8 @@ const StatisticsPage = () => {
 
   const [activeGame, setActiveGame] = useState(null);
 
+  const { updateLearnedLessons, learnedLessons } = React.useContext(PreferencesContext);
+
   const formatTime = (seconds) => {
     // Get minutes and remaining seconds
     const minutes = Math.floor(seconds / 60);
@@ -76,8 +78,6 @@ const StatisticsPage = () => {
       React.useCallback(() => {
     grabCurrentGame(USERACTIVEGAMESBFFURL);
   }, []));
-
-  const { updateLearnedLessons, learnedLessons } = React.useContext(PreferencesContext);
 
   return (
     <SafeAreaProvider>

--- a/sudokuru/app/Pages/StatisticsPage.tsx
+++ b/sudokuru/app/Pages/StatisticsPage.tsx
@@ -75,7 +75,7 @@ const StatisticsPage = () => {
 
   useFocusEffect(() => {
     grabCurrentGame(USERACTIVEGAMESBFFURL);
-  });
+  }, []);
 
   const { updateLearnedLessons, learnedLessons } = React.useContext(PreferencesContext);
 

--- a/sudokuru/app/Types/env/env.d.ts
+++ b/sudokuru/app/Types/env/env.d.ts
@@ -4,4 +4,5 @@ declare module '@env' {
     export const AUDIENCE: string;
     export const SCOPE: string;
     export const USERACTIVEGAMESBFFURL: string;
+    export const USERGAMESTATISTICSBFFURL: string;
 }

--- a/sudokuru/package-lock.json
+++ b/sudokuru/package-lock.json
@@ -42,7 +42,7 @@
         "react-native-screens": "~3.20.0",
         "react-native-svg": "13.4.0",
         "react-native-web": "~0.18.12",
-        "sudokuru": "^1.15.0"
+        "sudokuru": "^1.16.0"
       },
       "devDependencies": {
         "@babel/core": "^7.20.0",
@@ -17865,9 +17865,9 @@
       "integrity": "sha512-rlBo3HU/1zAJUrkY6jNxDOC9eVYliG6nS4JA8u8KAshITd07tafMc/Br7xQwCSseXwJ2iCcHCE8SNWX3q8Z+kw=="
     },
     "node_modules/sudokuru": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/sudokuru/-/sudokuru-1.15.0.tgz",
-      "integrity": "sha512-IsSiJCkm3rz633Pg5glBvyO4B9KRcrIjovG6Ka+PyseIJwGUFqQjMlPNBuEq4qJFlfRpcs7qTcFosx84hz4qJQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/sudokuru/-/sudokuru-1.16.0.tgz",
+      "integrity": "sha512-LXVLrZaPwT4uKVlyLBlt771jBWqFpKWDajFWtiicHVl2ghHss3ku4lKb9DDzFISQQp8deRu611hJLo2p7xTR1Q==",
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.18.2",
@@ -33304,9 +33304,9 @@
       "integrity": "sha512-rlBo3HU/1zAJUrkY6jNxDOC9eVYliG6nS4JA8u8KAshITd07tafMc/Br7xQwCSseXwJ2iCcHCE8SNWX3q8Z+kw=="
     },
     "sudokuru": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/sudokuru/-/sudokuru-1.15.0.tgz",
-      "integrity": "sha512-IsSiJCkm3rz633Pg5glBvyO4B9KRcrIjovG6Ka+PyseIJwGUFqQjMlPNBuEq4qJFlfRpcs7qTcFosx84hz4qJQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/sudokuru/-/sudokuru-1.16.0.tgz",
+      "integrity": "sha512-LXVLrZaPwT4uKVlyLBlt771jBWqFpKWDajFWtiicHVl2ghHss3ku4lKb9DDzFISQQp8deRu611hJLo2p7xTR1Q==",
       "requires": {
         "cors": "^2.8.5",
         "express": "^4.18.2",

--- a/sudokuru/package.json
+++ b/sudokuru/package.json
@@ -46,7 +46,7 @@
     "react-native-screens": "~3.20.0",
     "react-native-svg": "13.4.0",
     "react-native-web": "~0.18.12",
-    "sudokuru": "^1.15.0"
+    "sudokuru": "^1.16.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
Changelog:
- Updated env template file 
- Added UserGameStatisticsBFF Microservice to docker and pipeline
- Storing user's learned lessons in Context with theme
- Added missing lessons to Carousel
- Drill buttons in Drawer only render if user has completed the respective lesson
- Drill button and Play button throw alert message if required lessons have not been completed
- Lessons have button at end for user to press to say they have mastered the lesson
- Statistics page tracks user's learned lessons
- Statistics page has "Delete Statistics" button to clear statistics of user
- Updated Sudokuru package


## Checklist for completing pull request:
- [ ] Test functionality on Android and web (iOS optional but encouraged)
- [ ] Verify that any unit tests for new functionality are created and functional.
- [ ] If needed, update the Readme