### PR TITLE
Updating concurrency rules

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -11,8 +11,9 @@ on:
 
 # https://stackoverflow.com/questions/74117321/if-condition-in-concurrency-in-gha
 # A PR will have workflows in the same group, different PRs will have workflows in different groups, and each main workflow will have different group IDs
-group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
-cancel-in-progress: true
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   app_preview_dev:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -10,7 +10,7 @@ on:
 
 
 # https://stackoverflow.com/questions/74117321/if-condition-in-concurrency-in-gha
-# Each PR will share a group ID, each main workflow will have different group IDs
+# A PR will have workflows in the same group, different PRs will have workflows in different groups, and each main workflow will have different group IDs
 group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
 cancel-in-progress: true
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -8,7 +8,11 @@ on:
     branches:
       - main
 
-concurrency: main_workflow
+
+# https://stackoverflow.com/questions/74117321/if-condition-in-concurrency-in-gha
+# Each PR will share a group ID, each main workflow will have different group IDs
+group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+cancel-in-progress: true
 
 jobs:
   app_preview_dev:


### PR DESCRIPTION
Changelog:

Below summary is taken from here: https://stackoverflow.com/questions/74117321/if-condition-in-concurrency-in-gha

master
- Since every single group identifier on master is always unique (due to the github.run_id), a cancel-in-progress: true doesn't really affect it.

PRs
- Workflow name in combination with a branch ref (or you can even use a branch name) ensures that the same workflow gets cancelled only within that one branch.
- Two developers can push at the same time in their own PRs and the same workflow will run for both of them.
= One developer pushing multiple times in their own PR will always have only the latest commit running in CI. All previous ones will be cancelled.

## Checklist for completing pull request:
- [ ] Test functionality on Android and web (iOS optional but encouraged)
- [ ] Verify that any unit tests for new functionality are created and functional.
- [ ] If needed, update the Readme