### PR TITLE
Fixing issue with inputing numbers into sudoku board

### DIFF
--- a/app/Components/Sudoku Board/SudokuBoard.tsx
+++ b/app/Components/Sudoku Board/SudokuBoard.tsx
@@ -242,8 +242,6 @@ const SudokuBoard = (props: any) => {
   const [solution, setSolution] = useState();
   const [activeGame, setActiveGame] = useState();
 
-  const [gameType, setGameType] = useState();
-
   // drill states
   // These could probably stay as props since these values are constant and not altered.
   const [drillSolutionCells, setDrillSolutionCells] = useState();

--- a/app/Components/Sudoku Board/SudokuBoard.tsx
+++ b/app/Components/Sudoku Board/SudokuBoard.tsx
@@ -45,10 +45,6 @@ import Puzzle from "./Components/Puzzle";
 import { gameResults } from "sudokuru";
 import { Puzzles } from "../../Functions/Api/Puzzles";
 
-let drillMode = false;
-
-let landingMode = false;
-
 let fallbackHeight = 30;
 
 // Global variables for activeGame elements
@@ -245,6 +241,8 @@ const SudokuBoard = (props: any) => {
   const [historyOffSet, setHistoryOffSet] = useState<number>();
   const [solution, setSolution] = useState();
   const [activeGame, setActiveGame] = useState();
+
+  const [gameType, setGameType] = useState();
 
   // drill states
   // These could probably stay as props since these values are constant and not altered.
@@ -841,8 +839,8 @@ const SudokuBoard = (props: any) => {
         game={game}
         showResults={props.showGameResults}
         gameType={props.gameType}
-        landingMode={landingMode}
-        drillMode={drillMode}
+        landingMode={props.gameType == "Demo"}
+        drillMode={props.gameType == "StartDrill"}
       />
     );
   };
@@ -930,10 +928,17 @@ const SudokuBoard = (props: any) => {
     let inHintMode = board.get("inHintMode");
     let inNoteMode = board.get("inNoteMode");
     const inputValue = event.nativeEvent.key;
-    if (/^[1-9]$/.test(inputValue) && !inHintMode && !landingMode) {
+    if (
+      /^[1-9]$/.test(inputValue) &&
+      !inHintMode &&
+      !(props.gameType == "Demo")
+    ) {
       // check if input is a digit from 1 to 9
-      if (inNoteMode) addNumberAsNote(parseInt(inputValue, 10));
-      else fillNumber(parseInt(inputValue, 10));
+      if (inNoteMode) {
+        addNumberAsNote(parseInt(inputValue, 10));
+      } else {
+        fillNumber(parseInt(inputValue, 10));
+      }
     }
     if ((inputValue == "Delete" || inputValue == "Backspace") && !inHintMode)
       eraseSelected();
@@ -1066,30 +1071,33 @@ const SudokuBoard = (props: any) => {
     );
   };
 
-  drillMode = props.gameType == "StartDrill";
-  landingMode = props.gameType == "Demo";
   let inHintMode = board ? board.get("inHintMode") : false;
 
   return (
     <View
       testID={
-        landingMode
+        props.gameType == "Demo"
           ? "sudokuDemoBoard"
-          : drillMode
+          : props.gameType == "StartDrill"
           ? "sudokuDrillBoard"
           : "sudokuBoard"
       }
       onKeyDown={handleKeyDown}
       styles={{ borderWidth: 1 }}
     >
-      {board && !landingMode && !drillMode && renderTopBar()}
+      {board &&
+        !(props.gameType == "Demo") &&
+        !(props.gameType == "StartDrill") &&
+        renderTopBar()}
       {board && renderPuzzle()}
       {board && (
         <View style={styles().bottomActions}>
-          {!landingMode && renderActions()}
-          {!landingMode && !inHintMode && renderNumberControl()}
-          {drillMode && !inHintMode && renderSubmitButton()}
-          {!landingMode && inHintMode && renderHintSection()}
+          {!(props.gameType == "Demo") && renderActions()}
+          {!(props.gameType == "Demo") && !inHintMode && renderNumberControl()}
+          {props.gameType == "StartDrill" &&
+            !inHintMode &&
+            renderSubmitButton()}
+          {!(props.gameType == "Demo") && inHintMode && renderHintSection()}
         </View>
       )}
     </View>


### PR DESCRIPTION
Changelog:
- By storing landingMode and drillMode in a variable, that variable had the same memory location accross all instances of the Sudoku Board component
- This meant that the Demo board was constantly setting the isLanding variable to true
- This meant that while isLanding was true, user could not input values into the board until the play board updated isLanding to false
- The UI number pad never had this issue because we did not check the isLanding variable, since the numpad UI is not displayed for the Demo board. 

## Checklist for completing pull request:
- [ ] Test functionality on Android, iOS, and Web
- [ ] ~~Verify that any unit tests for new functionality are created and functional.~~ Too complex, don't know how.
- [ ] If needed, update the Readme