### PR TITLE
Disabling Cypress Recording for CI 

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -115,6 +115,7 @@ jobs:
         uses: cypress-io/github-action@v5
         with:
           start: 'npm run web:dev'
+          command: 'npm run test:cypress'
           wait-on: 'http://localhost:19000/'
           wait-on-timeout: 120
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -119,18 +119,6 @@ jobs:
           wait-on: 'http://localhost:19000/'
           wait-on-timeout: 120
 
-      - uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: cypress-screenshots
-          path: ./cypress/screenshots
-
-      - uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: cypress-videos
-          path: ./cypress/videos
-
       - name: Coveralls
         uses: coverallsapp/github-action@v2
 


### PR DESCRIPTION
Changelog:
- Updated pipeline cypress run action to disable video recording and screenshots
- This decreased the runtime of the tests from 13 minutes to 9 minutes


## Checklist for completing pull request:
- [ ] ~~Test functionality on Android, iOS, and Web~~
- [ ] ~~Verify that any unit tests for new functionality are created and functional.~~
- [ ] ~~If needed, update the Readme~~