### PR TITLE
Fixing infinite stack issue

### DIFF
--- a/app/Components/Sudoku Board/Components/HeaderRow.tsx
+++ b/app/Components/Sudoku Board/Components/HeaderRow.tsx
@@ -37,7 +37,6 @@ const HeaderRow = (props: HeaderRowProps) => {
 
   const handlePause = () => {
     saveGame(sudokuBoard);
-
     navigation.goBack();
   };
 

--- a/app/Components/Sudoku Board/Components/HeaderRow.tsx
+++ b/app/Components/Sudoku Board/Components/HeaderRow.tsx
@@ -37,7 +37,8 @@ const HeaderRow = (props: HeaderRowProps) => {
 
   const handlePause = () => {
     saveGame(sudokuBoard);
-    navigation.replace("PlayPage");
+
+    navigation.goBack();
   };
 
   return (


### PR DESCRIPTION
Updating so that pause game uses navigation.goBack() instead of navigation.replace() to prevent the navigation stack from increasing in size every time a game is paused and resumed. This will keep the dom smaller and will make e2e tests easier to write to prevent duplicate elements on the play page. 

## Checklist for completing pull request:
- [ ] Test functionality on Mobile, Web, and Desktop
- [ ] Verify that any tests for new functionality are created and functional.
- [ ] If needed, update the Readme