### PR TITLE
Board hotkeys now work when board is not selected

### DIFF
--- a/app/Components/Sudoku Board/SudokuBoard.tsx
+++ b/app/Components/Sudoku Board/SudokuBoard.tsx
@@ -572,9 +572,12 @@ const SudokuBoard = (props: SudokuBoardProps) => {
     );
   };
 
+  console.log("HELLO FRIENDS");
+
   return (
     <View
       testID={"sudokuBoard"}
+      //@ts-ignore react-native-web types not supported: https://github.com/necolas/react-native-web/issues/1684
       onKeyDown={handleKeyDown}
       style={{
         alignItems: "center",

--- a/app/Components/Sudoku Board/SudokuBoard.tsx
+++ b/app/Components/Sudoku Board/SudokuBoard.tsx
@@ -441,8 +441,6 @@ const SudokuBoard = (props: SudokuBoardProps) => {
   const handleKeyDown = (event: any) => {
     const inputValue = event.nativeEvent.key;
 
-    console.log(inputValue);
-
     switch (inputValue) {
       case "u":
       case "U":

--- a/app/Components/Sudoku Board/SudokuBoard.tsx
+++ b/app/Components/Sudoku Board/SudokuBoard.tsx
@@ -434,11 +434,30 @@ const SudokuBoard = (props: SudokuBoardProps) => {
   };
 
   const handleKeyDown = (event: any) => {
+    const inputValue = event.nativeEvent.key;
+
+    if (inputValue == "u" || inputValue == "U") {
+      const isUndoButtonDisabled =
+        sudokuBoard.actionHistory == null ||
+        sudokuBoard.actionHistory.length == 0;
+      if (!isUndoButtonDisabled) {
+        undo();
+      }
+    } else if (inputValue == "p" || inputValue == "P") {
+      handlePause(sudokuBoard, navigation);
+    } else if (
+      inputValue == "t" ||
+      inputValue == "T" ||
+      inputValue == "n" ||
+      inputValue == "N"
+    ) {
+      toggleNoteMode();
+    }
+
     if (sudokuBoard.selectedCell == null) {
       return;
     }
 
-    const inputValue = event.nativeEvent.key;
     if (/^[1-9]$/.test(inputValue)) {
       updateCellEntry(parseInt(inputValue, 10));
     } else if (
@@ -449,18 +468,7 @@ const SudokuBoard = (props: SudokuBoardProps) => {
       inputValue == "E" // e and E are for erase
     ) {
       eraseSelected();
-    } else if (inputValue == "u" || inputValue == "U") {
-      undo();
-    } else if (inputValue == "p" || inputValue == "P") {
-      handlePause(sudokuBoard, navigation);
-    } else if (
-      inputValue == "t" ||
-      inputValue == "T" ||
-      inputValue == "n" ||
-      inputValue == "N"
-    ) {
-      toggleNoteMode();
-    } else if (sudokuBoard.selectedCell) {
+    } else {
       let newCol = sudokuBoard.selectedCell.c;
       let newRow = sudokuBoard.selectedCell.r;
       switch (inputValue) {

--- a/app/Components/Sudoku Board/SudokuBoard.tsx
+++ b/app/Components/Sudoku Board/SudokuBoard.tsx
@@ -433,73 +433,83 @@ const SudokuBoard = (props: SudokuBoardProps) => {
     ];
   };
 
+  /**
+   * When a user presses a key down, do the desired action
+   * @param event onKeyDown event for react-native-web documented here: https://necolas.github.io/react-native-web/docs/interactions/#keyboardevent-props-api
+   * @returns void
+   */
   const handleKeyDown = (event: any) => {
     const inputValue = event.nativeEvent.key;
 
-    if (inputValue == "u" || inputValue == "U") {
-      const isUndoButtonDisabled =
-        sudokuBoard.actionHistory == null ||
-        sudokuBoard.actionHistory.length == 0;
-      if (!isUndoButtonDisabled) {
-        undo();
-      }
-    } else if (inputValue == "p" || inputValue == "P") {
-      handlePause(sudokuBoard, navigation);
-    } else if (
-      inputValue == "t" ||
-      inputValue == "T" ||
-      inputValue == "n" ||
-      inputValue == "N"
-    ) {
-      toggleNoteMode();
+    switch (inputValue) {
+      case "u":
+      case "U":
+        const isUndoButtonDisabled =
+          sudokuBoard.actionHistory == null ||
+          sudokuBoard.actionHistory.length == 0;
+        if (!isUndoButtonDisabled) {
+          undo();
+        }
+        return;
+      case "p":
+      case "P":
+        handlePause(sudokuBoard, navigation);
+        return;
+      case "t":
+      case "T":
+      case "n":
+      case "N":
+        toggleNoteMode();
+      default:
+        break;
     }
 
     if (sudokuBoard.selectedCell == null) {
       return;
     }
 
-    if (/^[1-9]$/.test(inputValue)) {
-      updateCellEntry(parseInt(inputValue, 10));
-    } else if (
-      inputValue == "Delete" ||
-      inputValue == "Backspace" ||
-      inputValue == "0" ||
-      inputValue == "e" ||
-      inputValue == "E" // e and E are for erase
-    ) {
-      eraseSelected();
-    } else {
-      let newCol = sudokuBoard.selectedCell.c;
-      let newRow = sudokuBoard.selectedCell.r;
-      switch (inputValue) {
-        case "ArrowLeft":
-        case "a":
-        case "A":
-          newCol = wrapDigit(newCol - 1);
-          break;
-        case "ArrowRight":
-        case "d":
-        case "D":
-          newCol = wrapDigit(newCol + 1);
-          break;
-        case "ArrowUp":
-        case "w":
-        case "W":
-          newRow = wrapDigit(newRow - 1);
-          break;
-        case "ArrowDown":
-        case "s":
-        case "S":
-          newRow = wrapDigit(newRow + 1);
-          break;
-        default:
-          return;
-      }
-      setSudokuBoard({
-        ...sudokuBoard,
-        selectedCell: { r: newRow, c: newCol },
-      });
+    let newCol = sudokuBoard.selectedCell.c;
+    let newRow = sudokuBoard.selectedCell.r;
+    switch (inputValue) {
+      case /^[1-9]$/.test(inputValue):
+        updateCellEntry(parseInt(inputValue, 10));
+        return;
+      case "Delete":
+      case "Backspace":
+      case "0":
+      case "e":
+      case "E":
+        eraseSelected();
+        return;
+      // below cases do not return to allow for update of selected cell
+      // todo create function for updating selectedCell for below cases to call
+      case "ArrowLeft":
+      case "a":
+      case "A":
+        newCol = wrapDigit(newCol - 1);
+        break;
+      case "ArrowRight":
+      case "d":
+      case "D":
+        newCol = wrapDigit(newCol + 1);
+        break;
+      case "ArrowUp":
+      case "w":
+      case "W":
+        newRow = wrapDigit(newRow - 1);
+        break;
+      case "ArrowDown":
+      case "s":
+      case "S":
+        newRow = wrapDigit(newRow + 1);
+        break;
+      default:
+        return;
     }
+    setSudokuBoard({
+      ...sudokuBoard,
+      selectedCell: { r: newRow, c: newCol },
+    });
   };
 
   const renderPuzzle = () => {

--- a/app/Components/Sudoku Board/SudokuBoard.tsx
+++ b/app/Components/Sudoku Board/SudokuBoard.tsx
@@ -441,6 +441,8 @@ const SudokuBoard = (props: SudokuBoardProps) => {
   const handleKeyDown = (event: any) => {
     const inputValue = event.nativeEvent.key;
 
+    console.log(inputValue);
+
     switch (inputValue) {
       case "u":
       case "U":
@@ -460,6 +462,7 @@ const SudokuBoard = (props: SudokuBoardProps) => {
       case "n":
       case "N":
         toggleNoteMode();
+        return;
       default:
         break;
     }
@@ -468,12 +471,14 @@ const SudokuBoard = (props: SudokuBoardProps) => {
       return;
     }
 
+    if (/^[1-9]$/.test(inputValue)) {
+      updateCellEntry(parseInt(inputValue, 10));
+      return;
+    }
+
     let newCol = sudokuBoard.selectedCell.c;
     let newRow = sudokuBoard.selectedCell.r;
     switch (inputValue) {
-      case /^[1-9]$/.test(inputValue):
-        updateCellEntry(parseInt(inputValue, 10));
-        return;
       case "Delete":
       case "Backspace":
       case "0":

--- a/app/Components/Sudoku Board/SudokuBoard.tsx
+++ b/app/Components/Sudoku Board/SudokuBoard.tsx
@@ -572,8 +572,6 @@ const SudokuBoard = (props: SudokuBoardProps) => {
     );
   };
 
-  console.log("HELLO FRIENDS");
-
   return (
     <View
       testID={"sudokuBoard"}

--- a/e2e/web/specs/buttons-and-shortcuts.spec.ts
+++ b/e2e/web/specs/buttons-and-shortcuts.spec.ts
@@ -303,7 +303,6 @@ test.describe("toggle notes", () => {
         await sudokuBoard.page.keyboard.press(key);
       }
       await sudokuBoard.cellHasValue(7, 7, "0");
-      await sudokuBoard.cell[7][7].click();
       await sudokuBoard.page.keyboard.press("1");
       await sudokuBoard.cellHasNotes(7, 7, "1");
       if (key === "button") {

--- a/e2e/web/specs/buttons-and-shortcuts.spec.ts
+++ b/e2e/web/specs/buttons-and-shortcuts.spec.ts
@@ -10,7 +10,6 @@ test.describe("pause", () => {
     let capital = key === "P" ? "capital " : "";
     test("pause button: " + capital + key, async ({ resumeGame }) => {
       const sudokuBoard = new SudokuBoardComponent(resumeGame);
-      await sudokuBoard.cell[0][0].click();
       if (key === "button") {
         await sudokuBoard.pause.click();
       } else {
@@ -85,6 +84,7 @@ test.describe("undo", () => {
         await sudokuBoard.cell[7][7].click();
         await sudokuBoard.cell[7][7].press("1");
         await sudokuBoard.cellHasValue(7, 7, "1");
+        await sudokuBoard.cell[7][7].click();
         if (key === "button") {
           await sudokuBoard.undo.click();
         } else {
@@ -296,13 +296,13 @@ test.describe("toggle notes", () => {
     let capital = key === "N" || key === "T" ? "capital " : "";
     test("toggle notes: " + capital + key, async ({ resumeGame }) => {
       const sudokuBoard = new SudokuBoardComponent(resumeGame);
-      await sudokuBoard.cell[7][7].click();
       if (key === "button") {
         await sudokuBoard.note.click();
       } else {
         await sudokuBoard.page.keyboard.press(key);
       }
       await sudokuBoard.cellHasValue(7, 7, "0");
+      await sudokuBoard.cell[7][7].click();
       await sudokuBoard.page.keyboard.press("1");
       await sudokuBoard.cellHasNotes(7, 7, "1");
       if (key === "button") {

--- a/e2e/web/specs/buttons-and-shortcuts.spec.ts
+++ b/e2e/web/specs/buttons-and-shortcuts.spec.ts
@@ -10,6 +10,7 @@ test.describe("pause", () => {
     let capital = key === "P" ? "capital " : "";
     test("pause button: " + capital + key, async ({ resumeGame }) => {
       const sudokuBoard = new SudokuBoardComponent(resumeGame);
+      await sudokuBoard.cell[0][0].click();
       if (key === "button") {
         await sudokuBoard.pause.click();
       } else {
@@ -84,7 +85,6 @@ test.describe("undo", () => {
         await sudokuBoard.cell[7][7].click();
         await sudokuBoard.cell[7][7].press("1");
         await sudokuBoard.cellHasValue(7, 7, "1");
-        await sudokuBoard.cell[7][7].click();
         if (key === "button") {
           await sudokuBoard.undo.click();
         } else {
@@ -296,6 +296,7 @@ test.describe("toggle notes", () => {
     let capital = key === "N" || key === "T" ? "capital " : "";
     test("toggle notes: " + capital + key, async ({ resumeGame }) => {
       const sudokuBoard = new SudokuBoardComponent(resumeGame);
+      await sudokuBoard.cell[7][7].click();
       if (key === "button") {
         await sudokuBoard.note.click();
       } else {


### PR DESCRIPTION
Changelog:
- pause, undo, and toggle notes hotkeys now work when board is not selected (As long as board has been selected previously)
- ignoring react-native-web typescript 'error', react-native-web does not have supported Typescript types: `https://github.com/necolas/react-native-web/issues/1684`
Additional work will need to be done to get hotkeys working on initial puzzle load. 

## Checklist for completing pull request:
- [x] Test functionality on Mobile, Web, and Desktop
- [ ] Verify that any tests for new functionality are created and functional.
- [ ] If needed, update the Readme