### PR TITLE
Adding react-native-web types

### DIFF
--- a/app/Components/SudokuBoard/Components/Cell.tsx
+++ b/app/Components/SudokuBoard/Components/Cell.tsx
@@ -116,7 +116,6 @@ const Cell = (props: RenderCellProps) => {
           justifyContent: "center",
           borderWidth: cellSize ? cellSize / 40 : fallbackHeight / 40,
           backgroundColor: backgroundColor,
-          // @ts-ignore
           outline: "none",
         },
         c % 3 === 0 ? { borderLeftWidth: getOutsideBorderWidth() } : null,

--- a/app/Components/SudokuBoard/SudokuBoard.tsx
+++ b/app/Components/SudokuBoard/SudokuBoard.tsx
@@ -1247,7 +1247,6 @@ const SudokuBoard = (props: SudokuBoardProps) => {
   return (
     <View
       testID={"sudokuBoard"}
-      //@ts-ignore react-native-web types not supported: https://github.com/necolas/react-native-web/issues/1684
       onKeyDown={handleKeyDown}
       style={{
         alignItems: "center",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "@types/dotenv-safe": "^8.1.5",
         "@types/node": "^20.11.17",
         "@types/react": "~18.2.79",
+        "@types/react-native-web": "^0.19.0",
         "babel-plugin-istanbul": "^6.1.1",
         "cross-env": "^7.0.3",
         "cypress": "^13.6.4",
@@ -7958,6 +7959,17 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-native-web": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@types/react-native-web/-/react-native-web-0.19.0.tgz",
+      "integrity": "sha512-HWagkGzM/k1iPBy2/xnVU9U0MN9oswZu8/2buh8bnuhwJpgt7avPoGlqT9XuFNlBbQykCg5TfEyXoUJR8tGDGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@types/responselike": {
@@ -32924,6 +32936,16 @@
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-native-web": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@types/react-native-web/-/react-native-web-0.19.0.tgz",
+      "integrity": "sha512-HWagkGzM/k1iPBy2/xnVU9U0MN9oswZu8/2buh8bnuhwJpgt7avPoGlqT9XuFNlBbQykCg5TfEyXoUJR8tGDGg==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*",
+        "react-native": "*"
       }
     },
     "@types/responselike": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@types/dotenv-safe": "^8.1.5",
     "@types/node": "^20.11.17",
     "@types/react": "~18.2.79",
+    "@types/react-native-web": "^0.19.0",
     "babel-plugin-istanbul": "^6.1.1",
     "cross-env": "^7.0.3",
     "cypress": "^13.6.4",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "module": "commonjs",
     "outDir": "dist",
     "rootDir": ".",
-    "types": ["node"],
+    "types": ["node", "react-native-web"],
     "noEmit": false
   },
   "exclude": ["./node_modules", "**/*.test.ts"]


### PR DESCRIPTION
React-Native-Web now has Typescript types, and we can remove some @ts-ignores we had in the codebase:
https://necolas.github.io/react-native-web/docs/typescript-support/

## Checklist for completing pull request:
- [ ] Update Changelog.json if any functionality has been changed for the end user.
- [ ] Test functionality on Mobile, Web, and Desktop
- [ ] Verify that any tests for new functionality are created and functional.
- [ ] If needed, update the Readme