### PR TITLE
Fix resume game functionality

### DIFF
--- a/Changelog.json
+++ b/Changelog.json
@@ -1,5 +1,15 @@
 [
   {
+    "version": "1.27.1",
+    "date": "November 2nd, 2024",
+    "summary": "Fixed bug where Sudoku games were not being saved and could not be resumed after pausing.",
+    "bug fixes": [
+      "Fixed bug where Sudoku games were not being saved and could not be resumed after pausing."
+    ],
+    "targets": ["web", "mobile", "desktop"],
+    "contributors": ["Thomas-Gallant"]
+  },
+  {
     "version": "1.27.0",
     "date": "November 2nd, 2024",
     "summary": "Renaming Sudoku strategies to allow for better translations and align with Sudoku.com terminology.",

--- a/app/Components/SudokuBoard/Components/HeaderRow.tsx
+++ b/app/Components/SudokuBoard/Components/HeaderRow.tsx
@@ -5,7 +5,6 @@ import { useTheme, Text } from "react-native-paper";
 import { SudokuObjectProps } from "../../../Functions/LocalDatabase";
 import {
   getCellSize,
-  saveGame,
   formatTime,
   handlePause,
 } from "../Functions/BoardFunctions";

--- a/app/Components/SudokuBoard/Functions/BoardFunctions.ts
+++ b/app/Components/SudokuBoard/Functions/BoardFunctions.ts
@@ -1,7 +1,7 @@
 import { useWindowDimensions } from "react-native";
 import { SudokuObjectProps } from "../../../Functions/LocalDatabase";
 import { calculateGameScore, GameDifficulty } from "./Difficulty";
-import { finishGame } from "../../../Api/Puzzles";
+import { finishGame, saveGame } from "../../../Api/Puzzles";
 import { SudokuStrategy } from "sudokuru";
 /**
  * This is a temporary place to store functions
@@ -59,14 +59,6 @@ export const formatTime = (inputSeconds: number) => {
   // Return formatted string
   return `${paddedDays}${paddedHours}${paddedMinutes}${paddedSeconds}`;
 };
-
-export async function saveGame(activeGame: SudokuObjectProps) {
-  saveGame(activeGame).then((res: any) => {
-    if (res) {
-      console.log("Game progress was saved successfully!");
-    }
-  });
-}
 
 /**
  * Calculates and returns the score of the game.

--- a/app/Components/SudokuBoard/SudokuBoard.tsx
+++ b/app/Components/SudokuBoard/SudokuBoard.tsx
@@ -3,7 +3,6 @@ import { View } from "react-native";
 import {
   finishSudokuGame,
   handlePause,
-  saveGame,
   isValueCorrect,
 } from "./Functions/BoardFunctions";
 import {
@@ -43,6 +42,7 @@ import { useNavigation } from "@react-navigation/native";
 import Hint from "./Components/Hint";
 import { GameDifficulty } from "./Functions/Difficulty";
 import { SudokuStrategy } from "sudokuru";
+import { saveGame } from "../../Api/Puzzles";
 
 export interface SudokuBoardProps {
   action: "StartGame" | "ResumeGame";

--- a/e2e/web/page/play.page.ts
+++ b/e2e/web/page/play.page.ts
@@ -3,7 +3,7 @@ import { Locator, Page, expect } from "@playwright/test";
 export class PlayPage {
   readonly page: Page;
   readonly title: Locator;
-  readonly start: Locator;
+  readonly resume: Locator;
   readonly noviceDesc: Locator;
   readonly amateurDesc: Locator;
   readonly laymanDesc: Locator;
@@ -22,7 +22,7 @@ export class PlayPage {
   constructor(page: Page) {
     this.page = page;
     this.title = page.getByTestId("playPageTitle");
-    this.start = page.getByText("Start Puzzle");
+    this.resume = page.getByText("Resume Puzzle");
     this.noviceDesc = page.getByTestId("NoviceDescription");
     this.amateurDesc = page.getByTestId("AmateurDescription");
     this.laymanDesc = page.getByTestId("LaymanDescription");
@@ -43,6 +43,10 @@ export class PlayPage {
 
   async playPageIsRendered() {
     await expect(this.title).toBeInViewport({ ratio: 1 });
+  }
+
+  async resumeButtonIsVisible() {
+    await expect(this.resume).toBeInViewport({ ratio: 1 });
   }
 
   async fullTitleIsVisible() {

--- a/e2e/web/specs/board-buttons-and-shortcuts.spec.ts
+++ b/e2e/web/specs/board-buttons-and-shortcuts.spec.ts
@@ -39,6 +39,12 @@ test.describe("pause", () => {
       }
       const playPage = new PlayPage(resumeGame);
       await playPage.playPageIsRendered();
+      await playPage.resumeButtonIsVisible();
+
+      // verify the existing game is resumed.
+      await playPage.resume.click();
+      await sudokuBoard.cellHasValue(0, 0, "1");
+      await sudokuBoard.cellHasValue(8, 8, "9");
     });
   }
 });

--- a/e2e/web/specs/play-sudoku.spec.ts
+++ b/e2e/web/specs/play-sudoku.spec.ts
@@ -198,6 +198,18 @@ test.describe("start game", () => {
   });
 });
 
+test.describe("resume game", () => {
+  test("user can pause and resume a game", async ({ play }) => {
+    const playPage = new PlayPage(play);
+    await playPage.noviceDesc.click();
+    const sudokuBoard = new SudokuBoardComponent(play);
+    await sudokuBoard.pause.click();
+    await playPage.resumeButtonIsVisible();
+    await playPage.resume.click();
+    await expect(sudokuBoard.sudokuBoard).toContainText("novice");
+  });
+});
+
 test.describe("resize play page", () => {
   test("Difficulty stars and descriptions are visible on desktop sized screen", async ({
     play,


### PR DESCRIPTION
Changelog:
- Fix bug introduced with this PR https://github.com/Sudokuru/Frontend/pull/346 where resume game functionality was broken. This was caused during a function refactor which caused the saveGame function to be calling itself instead of the correct function
- Remove the wrapper intermediary saveGame function which isn't necessary
- Inroduce a test case which verifies that the site can save a puzzle to localstorage and resume a puzzle. All previous tests inserted a puzzle into localstorage and therefore that functionality wasn't being tested. 
- Expand the pause game tests, although this expansion of existing tests doesn't cover the saveGame functionality which is why a new test was created. 
- Remove the playwright locator for the "Start Game" button as that no longer exists and is legacy code

## Checklist for completing pull request:
- [x] Update Changelog.json if any functionality has been changed for the end user.
- [x] Test functionality on Mobile, Web, and Desktop
- [x] Verify that any tests for new functionality are created and functional.
- [x] If needed, update the Readme