### PR TITLE
Fixing issue where cells with notes were highlighted in green when identical values setting is turned on

### DIFF
--- a/e2e/web/specs/board-highlighting.spec.ts
+++ b/e2e/web/specs/board-highlighting.spec.ts
@@ -44,6 +44,9 @@ test.describe("board highlighting", () => {
       },
       { condition: (row, column) => true, color: NOT_HIGHLIGHTED_COLOR_RGB },
     ]);
+
+    await sudokuBoard.cell[7][8].click();
+    await sudokuBoard.cellHasColor(7, 8, SELECTED_COLOR_RGB);
   });
 
   test("should render correctly when cell is unselected", async ({

--- a/sudokuru/Changelog.json
+++ b/sudokuru/Changelog.json
@@ -1,7 +1,17 @@
 ﻿[
   {
-    "version": "1.28.0",
+    "version": "1.28.1",
     "date": "#{date}#",
+    "summary": "A selected cell with notes was incorrectly highlighted as green instead of blue when identical values setting was enabled.",
+    "bug fixes": [
+      "A selected cell with notes now is always highlighted as blue even when the identical values setting is enabled."
+    ],
+    "targets": ["web", "mobile", "desktop"],
+    "contributors": ["Thomas-Gallant"]
+  },
+  {
+    "version": "1.28.0",
+    "date": "January 19th, 2025",
     "summary": "Adding a progress indicator to the Sudoku board. By default, the user can see how many remaining cells of a particular value are left.",
     "features": [
       "User has new profile option - Progress Indicator. When enabled, the numpad will have a gradient showing the user how many remaining cells of a particular value are left."

--- a/sudokuru/app/Components/SudokuBoard/SudokuBoard.tsx
+++ b/sudokuru/app/Components/SudokuBoard/SudokuBoard.tsx
@@ -783,7 +783,11 @@ const SudokuBoard = (props: SudokuBoardProps) => {
     const { highlightIdenticalValuesSetting } =
       React.useContext(PreferencesContext);
     const currentSelectedCell = getSelectedCells();
-    const currentEntry = cell.entry;
+    let currentEntry = cell.entry;
+    // for the purposes of highlighting identical values, a cell with notes is treated as an empty cell
+    if (cell.type === "note"){
+      currentEntry = 0;
+    }
     const selectedEntry = currentSelectedCell[0].entry;
     const identicalValue = selectedEntry === currentEntry;
 

--- a/sudokuru/app/Components/SudokuBoard/SudokuBoard.tsx
+++ b/sudokuru/app/Components/SudokuBoard/SudokuBoard.tsx
@@ -785,7 +785,7 @@ const SudokuBoard = (props: SudokuBoardProps) => {
     const currentSelectedCell = getSelectedCells();
     let currentEntry = cell.entry;
     // for the purposes of highlighting identical values, a cell with notes is treated as an empty cell
-    if (cell.type === "note"){
+    if (cell.type === "note") {
       currentEntry = 0;
     }
     const selectedEntry = currentSelectedCell[0].entry;


### PR DESCRIPTION
Fixing issue where cells with notes were highlighted in green when identical values setting is turned on

Before:
![image](https://github.com/user-attachments/assets/81235f6b-af87-4c53-a38a-f101f4327d80)
After:
![image](https://github.com/user-attachments/assets/836acadb-6c1a-4b73-bb0c-6935a4b31522)


## Checklist for completing pull request:
- [x] Update Changelog.json if any functionality has been changed for the end user.
- [x] Test functionality on Mobile, Web, and Desktop
- [x] Verify that any tests for new functionality are created and functional.
- [ ] If needed, update the Readme

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes for Sudokuru v1.28.1

- **Bug Fixes**
  - Corrected cell highlighting for selected cells with notes
  - Ensured selected cells with notes are consistently highlighted in blue, even when identical values setting is enabled

- **Features**
  - Added progress indicator on Sudoku board to show remaining cells of a particular value (web, mobile, and desktop platforms)

- **Testing**
  - Enhanced board highlighting test suite with additional cell interaction verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->