### PR TITLE
Adding ability to initialize notes for a sudoku game

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 // https://docs.expo.dev/guides/using-eslint/
 module.exports = {
   extends: ["expo", "prettier"],
-  plugins: ["prettier"],
+  plugins: ["prettier", "eslint-plugin-json"],
   rules: {
     "prettier/prettier": "error",
   },

--- a/e2e/web/components/sudoku-board.component.ts
+++ b/e2e/web/components/sudoku-board.component.ts
@@ -158,6 +158,16 @@ export class SudokuBoardComponent {
     );
   }
 
+  async verifyAllCellsInBoard(
+    verificationFunction: (row: number, column: number) => Promise<void>,
+  ) {
+    for (let r = 0; r < this.numRows; r++) {
+      for (let c = 0; c < this.numColumns; c++) {
+        await verificationFunction(r, c);
+      }
+    }
+  }
+
   /**
    * For each cell in the puzzle, checks each condition starting from the first.
    * If the condition is valid then checks that the cell matches the expected color.

--- a/e2e/web/components/sudoku-board.component.ts
+++ b/e2e/web/components/sudoku-board.component.ts
@@ -117,6 +117,10 @@ export class SudokuBoardComponent {
     await expect(await cell.locator("*")).toHaveCount(0);
   }
 
+  async cellIsNotEmpty(row: number, column: number) {
+    await this.cellDoesNotHaveValue(row, column, "0");
+  }
+
   // we can take advantage of an empty cell having 0 child elements
   // and a cell with a value having 1 child element
   // therefore a cell with notes must have more than 1 child element

--- a/e2e/web/components/sudoku-board.component.ts
+++ b/e2e/web/components/sudoku-board.component.ts
@@ -103,6 +103,30 @@ export class SudokuBoardComponent {
     ).toBeInViewport({ ratio: 1 });
   }
 
+  async cellDoesNotHaveValue(row: number, column: number, value: string) {
+    await expect(
+      this.page.getByTestId(`cellr${row}c${column}value:${value}`),
+    ).not.toBeInViewport({ ratio: 1 });
+  }
+
+  // We can take advantage of an empty cell not having any child elements
+  async cellIsEmpty(row: number, column: number) {
+    const cell = await this.page.locator(
+      `[data-testid^="cellr${row}c${column}"]`,
+    );
+    await expect(await cell.locator("*")).toHaveCount(0);
+  }
+
+  // we can take advantage of an empty cell having 0 child elements
+  // and a cell with a value having 1 child element
+  // therefore a cell with notes must have more than 1 child element
+  async cellIsNotNote(row: number, column: number) {
+    const cell = await this.page.locator(
+      `[data-testid^="cellr${row}c${column}"]`,
+    );
+    await expect(await cell.locator("*").count()).toBeLessThanOrEqual(1);
+  }
+
   async cellHasNotes(row: number, column: number, notes: string) {
     await expect(
       this.page.getByTestId(`cellr${row}c${column}notes:${notes}`),

--- a/e2e/web/data/hidden-pair-profile.json
+++ b/e2e/web/data/hidden-pair-profile.json
@@ -6,6 +6,7 @@
   "highlightRow": true,
   "highlightIdenticalValues": true,
   "progressIndicator": true,
+  "initializeNotes": true,
   "previewMode": false,
   "strategyHintOrder": [
     "HIDDEN_PAIR",

--- a/e2e/web/data/hidden-quadruplet-profile.json
+++ b/e2e/web/data/hidden-quadruplet-profile.json
@@ -6,6 +6,7 @@
   "highlightRow": true,
   "highlightIdenticalValues": true,
   "progressIndicator": true,
+  "initializeNotes": true,
   "previewMode": false,
   "strategyHintOrder": [
     "HIDDEN_QUADRUPLET",

--- a/e2e/web/data/hidden-single-profile.json
+++ b/e2e/web/data/hidden-single-profile.json
@@ -6,6 +6,7 @@
   "highlightRow": true,
   "highlightIdenticalValues": true,
   "progressIndicator": true,
+  "initializeNotes": true,
   "previewMode": false,
   "strategyHintOrder": [
     "HIDDEN_SINGLE",

--- a/e2e/web/data/hidden-triplet-profile.json
+++ b/e2e/web/data/hidden-triplet-profile.json
@@ -6,6 +6,7 @@
   "highlightRow": true,
   "highlightIdenticalValues": true,
   "progressIndicator": true,
+  "initializeNotes": true,
   "previewMode": false,
   "strategyHintOrder": [
     "HIDDEN_TRIPLET",

--- a/e2e/web/data/obvious-pair-profile.json
+++ b/e2e/web/data/obvious-pair-profile.json
@@ -6,6 +6,7 @@
   "highlightRow": true,
   "highlightIdenticalValues": true,
   "progressIndicator": true,
+  "initializeNotes": true,
   "previewMode": false,
   "strategyHintOrder": [
     "OBVIOUS_PAIR",

--- a/e2e/web/data/obvious-quadruplet-profile.json
+++ b/e2e/web/data/obvious-quadruplet-profile.json
@@ -6,6 +6,7 @@
   "highlightRow": true,
   "highlightIdenticalValues": true,
   "progressIndicator": true,
+  "initializeNotes": true,
   "previewMode": false,
   "strategyHintOrder": [
     "OBVIOUS_QUADRUPLET",

--- a/e2e/web/data/obvious-triplet-profile.json
+++ b/e2e/web/data/obvious-triplet-profile.json
@@ -6,6 +6,7 @@
   "highlightRow": true,
   "highlightIdenticalValues": true,
   "progressIndicator": true,
+  "initializeNotes": true,
   "previewMode": false,
   "strategyHintOrder": [
     "OBVIOUS_TRIPLET",

--- a/e2e/web/data/pointing-pair-profile.json
+++ b/e2e/web/data/pointing-pair-profile.json
@@ -6,6 +6,7 @@
   "highlightRow": true,
   "highlightIdenticalValues": true,
   "progressIndicator": true,
+  "initializeNotes": true,
   "previewMode": false,
   "strategyHintOrder": [
     "POINTING_PAIR",

--- a/e2e/web/data/pointing-triplet-profile.json
+++ b/e2e/web/data/pointing-triplet-profile.json
@@ -6,6 +6,7 @@
   "highlightRow": true,
   "highlightIdenticalValues": true,
   "progressIndicator": true,
+  "initializeNotes": true,
   "previewMode": false,
   "strategyHintOrder": [
     "POINTING_TRIPLET",

--- a/e2e/web/page/profile.page.ts
+++ b/e2e/web/page/profile.page.ts
@@ -20,6 +20,8 @@ export class ProfilePage {
   readonly highlightColumnSwitchDisabled: Locator;
   readonly featurePreviewSwitchEnabled: Locator;
   readonly featurePreviewSwitchDisabled: Locator;
+  readonly initializeNotesSwitchEnabled: Locator;
+  readonly initializeNotesSwitchDisabled: Locator;
 
   readonly hintStrategyMenuUp: Locator;
   readonly hintStrategyMenuDown: Locator;
@@ -54,6 +56,12 @@ export class ProfilePage {
     );
     this.featurePreviewSwitchDisabled = page.getByTestId(
       "FeaturePreviewDisabled",
+    );
+    this.initializeNotesSwitchEnabled = page.getByTestId(
+      "InitializeNotesEnabled",
+    );
+    this.initializeNotesSwitchDisabled = page.getByTestId(
+      "InitializeNotesDisabled",
     );
 
     this.hintStrategyMenuUp = page.getByTestId("HintStrategyMenuUp");

--- a/e2e/web/specs/board-buttons-and-shortcuts.spec.ts
+++ b/e2e/web/specs/board-buttons-and-shortcuts.spec.ts
@@ -199,6 +199,8 @@ test.describe("Initialize Notes", () => {
     await expect(profilePage.initializeNotesSwitchEnabled).toBeInViewport({
       ratio: 1,
     });
+    await profilePage.initializeNotesSwitchEnabled.click();
+    await profilePage.initializeNotesSwitchDisabled.click();
     const headerComponent = new HeaderComponent(featurePreview);
     await headerComponent.drawer.click();
     await headerComponent.drawerPlay.click();

--- a/e2e/web/specs/board-buttons-and-shortcuts.spec.ts
+++ b/e2e/web/specs/board-buttons-and-shortcuts.spec.ts
@@ -205,7 +205,7 @@ test.describe("Initialize Notes", () => {
     await featurePreview.getByText("Novice").click();
     const sudokuBoardComponent = new SudokuBoardComponent(featurePreview);
     await sudokuBoardComponent.verifyAllCellsInBoard(async (r, c) => {
-      await sudokuBoardComponent.cellDoesNotHaveValue(r, c, "0");
+      await sudokuBoardComponent.cellIsNotEmpty(r, c);
     });
   });
 

--- a/e2e/web/specs/board-buttons-and-shortcuts.spec.ts
+++ b/e2e/web/specs/board-buttons-and-shortcuts.spec.ts
@@ -204,11 +204,9 @@ test.describe("Initialize Notes", () => {
     await headerComponent.drawerPlay.click();
     await featurePreview.getByText("Novice").click();
     const sudokuBoardComponent = new SudokuBoardComponent(featurePreview);
-    for (let r = 0; r < sudokuBoardComponent.numRows; r++) {
-      for (let c = 0; c < sudokuBoardComponent.numColumns; c++) {
-        await sudokuBoardComponent.cellDoesNotHaveValue(r, c, "0");
-      }
-    }
+    await sudokuBoardComponent.verifyAllCellsInBoard(async (r, c) => {
+      await sudokuBoardComponent.cellDoesNotHaveValue(r, c, "0");
+    });
   });
 
   test("should not initialize notes for all cells when disabled", async ({
@@ -216,11 +214,9 @@ test.describe("Initialize Notes", () => {
   }) => {
     await play.getByText("Novice").click();
     const sudokuBoardComponent = new SudokuBoardComponent(play);
-    for (let r = 0; r < sudokuBoardComponent.numRows; r++) {
-      for (let c = 0; c < sudokuBoardComponent.numColumns; c++) {
-        await sudokuBoardComponent.cellIsNotNote(r, c);
-      }
-    }
+    await sudokuBoardComponent.verifyAllCellsInBoard(async (r, c) => {
+      await sudokuBoardComponent.cellIsNotNote(r, c);
+    });
   });
 });
 

--- a/e2e/web/specs/board-buttons-and-shortcuts.spec.ts
+++ b/e2e/web/specs/board-buttons-and-shortcuts.spec.ts
@@ -8,6 +8,9 @@ import {
 } from "../data";
 import { getSingleMultiSelectKey } from "../playwright.config";
 import { SELECTED_IDENTICAL_VALUE_COLOR_RGB } from "../../../sudokuru/app/Styling/HighlightColors";
+import { ProfilePage } from "../page/profile.page";
+import { expect } from "@playwright/test";
+import { HeaderComponent } from "../components/header.component";
 
 test.describe("hint", () => {
   test.use({ gameToResume: AMEND_NOTES_EMPTY_CELL_GAME });
@@ -185,6 +188,39 @@ test.describe("progress indicator", () => {
   test("should not be visible when disabled", async ({ resumeGame }) => {
     const sudokuBoard = new SudokuBoardComponent(resumeGame);
     await sudokuBoard.progressIndicatorIsDisabled(initialProgressIndicator);
+  });
+});
+
+test.describe("Initialize Notes", () => {
+  test("should initialize notes for all cells when enabled", async ({
+    featurePreview,
+  }) => {
+    const profilePage = new ProfilePage(featurePreview);
+    await expect(profilePage.initializeNotesSwitchEnabled).toBeInViewport({
+      ratio: 1,
+    });
+    const headerComponent = new HeaderComponent(featurePreview);
+    await headerComponent.drawer.click();
+    await headerComponent.drawerPlay.click();
+    await featurePreview.getByText("Novice").click();
+    const sudokuBoardComponent = new SudokuBoardComponent(featurePreview);
+    for (let r = 0; r < sudokuBoardComponent.numRows; r++) {
+      for (let c = 0; c < sudokuBoardComponent.numColumns; c++) {
+        await sudokuBoardComponent.cellDoesNotHaveValue(r, c, "0");
+      }
+    }
+  });
+
+  test("should not initialize notes for all cells when disabled", async ({
+    play,
+  }) => {
+    await play.getByText("Novice").click();
+    const sudokuBoardComponent = new SudokuBoardComponent(play);
+    for (let r = 0; r < sudokuBoardComponent.numRows; r++) {
+      for (let c = 0; c < sudokuBoardComponent.numColumns; c++) {
+        await sudokuBoardComponent.cellIsNotNote(r, c);
+      }
+    }
   });
 });
 

--- a/e2e/web/specs/feature-preview.spec.ts
+++ b/e2e/web/specs/feature-preview.spec.ts
@@ -1,6 +1,6 @@
 import { ProfilePage } from "./../page/profile.page";
 import { test } from "../fixture";
-import { devices } from "@playwright/test";
+import { devices, expect } from "@playwright/test";
 import { HeaderComponent } from "../components/header.component";
 
 test.describe("feature preview", () => {
@@ -23,5 +23,26 @@ test.describe("feature preview", () => {
     const profilePage = new ProfilePage(page);
     await profilePage.featurePreviewSwitchDisabled.click();
     await headerComponent.partialFeaturePreviewTextIsVisible();
+  });
+
+  test.only("Initialze Notes profile setting appears in feature preview", async ({
+    featurePreview,
+  }) => {
+    const profilePage = new ProfilePage(featurePreview);
+    await expect(profilePage.initializeNotesSwitchEnabled).toBeInViewport({
+      ratio: 1,
+    });
+  });
+
+  test.only("Initialize Notes profile setting does not appear when feature preview is disabled", async ({
+    profile,
+  }) => {
+    const profilePage = new ProfilePage(profile);
+    await expect(profilePage.initializeNotesSwitchDisabled).not.toBeInViewport({
+      ratio: 1,
+    });
+    await expect(profilePage.initializeNotesSwitchEnabled).not.toBeInViewport({
+      ratio: 1,
+    });
   });
 });

--- a/e2e/web/specs/feature-preview.spec.ts
+++ b/e2e/web/specs/feature-preview.spec.ts
@@ -25,7 +25,7 @@ test.describe("feature preview", () => {
     await headerComponent.partialFeaturePreviewTextIsVisible();
   });
 
-  test("Initialze Notes profile setting appears in feature preview", async ({
+  test("Initialize Notes profile setting appears in feature preview", async ({
     featurePreview,
   }) => {
     const profilePage = new ProfilePage(featurePreview);

--- a/e2e/web/specs/feature-preview.spec.ts
+++ b/e2e/web/specs/feature-preview.spec.ts
@@ -25,7 +25,7 @@ test.describe("feature preview", () => {
     await headerComponent.partialFeaturePreviewTextIsVisible();
   });
 
-  test.only("Initialze Notes profile setting appears in feature preview", async ({
+  test("Initialze Notes profile setting appears in feature preview", async ({
     featurePreview,
   }) => {
     const profilePage = new ProfilePage(featurePreview);
@@ -34,7 +34,7 @@ test.describe("feature preview", () => {
     });
   });
 
-  test.only("Initialize Notes profile setting does not appear when feature preview is disabled", async ({
+  test("Initialize Notes profile setting does not appear when feature preview is disabled", async ({
     profile,
   }) => {
     const profilePage = new ProfilePage(profile);

--- a/e2e/web/specs/offlinestorage.spec.ts
+++ b/e2e/web/specs/offlinestorage.spec.ts
@@ -36,7 +36,7 @@ test.describe("Offline Storage", () => {
 
 test.describe("Offline Storage", () => {
   test.use({ activeGameStorage: {} });
-  test("Resume Game buton does not show with invalid active game object", async ({
+  test("Resume Game button does not show with invalid active game object", async ({
     page,
   }) => {
     await page.reload();

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "eslint": "8.57.0",
         "eslint-config-expo": "8.0.1",
         "eslint-config-prettier": "10.1.1",
+        "eslint-plugin-json": "^3.1.0",
         "eslint-plugin-prettier": "5.2.3",
         "prettier": "3.5.3",
         "snyk": "^1.1294.0",
@@ -8508,6 +8509,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eslint-plugin-json": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-json/-/eslint-plugin-json-3.1.0.tgz",
+      "integrity": "sha512-MrlG2ynFEHe7wDGwbUuFPsaT2b1uhuEFhJ+W1f1u+1C2EkXmTYJp4B1aAdQQ8M+CC3t//N/oRKiIVw14L2HR1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "vscode-json-languageservice": "^4.1.6"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
     "node_modules/eslint-plugin-prettier": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.3.tgz",
@@ -11916,6 +11931,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
@@ -17021,6 +17043,48 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz",
       "integrity": "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w=="
+    },
+    "node_modules/vscode-json-languageservice": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.2.1.tgz",
+      "integrity": "sha512-xGmv9QIWs2H8obGbWg+sIPI/3/pFgj/5OWBhNzs00BkYQ9UaB2F6JJaGB/2/YOZJ3BvLXQTC4Q7muqU25QgAhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-languageserver-textdocument": "^1.0.3",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-nls": "^5.0.0",
+        "vscode-uri": "^3.0.3"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-nls": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz",
+      "integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/walker": {
       "version": "1.0.8",
@@ -23458,6 +23522,16 @@
         }
       }
     },
+    "eslint-plugin-json": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-json/-/eslint-plugin-json-3.1.0.tgz",
+      "integrity": "sha512-MrlG2ynFEHe7wDGwbUuFPsaT2b1uhuEFhJ+W1f1u+1C2EkXmTYJp4B1aAdQQ8M+CC3t//N/oRKiIVw14L2HR1g==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.21",
+        "vscode-json-languageservice": "^4.1.6"
+      }
+    },
     "eslint-plugin-prettier": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.3.tgz",
@@ -25682,6 +25756,12 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
+    },
+    "jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true
     },
     "jsonfile": {
       "version": "6.1.0",
@@ -29253,6 +29333,43 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz",
       "integrity": "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w=="
+    },
+    "vscode-json-languageservice": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.2.1.tgz",
+      "integrity": "sha512-xGmv9QIWs2H8obGbWg+sIPI/3/pFgj/5OWBhNzs00BkYQ9UaB2F6JJaGB/2/YOZJ3BvLXQTC4Q7muqU25QgAhA==",
+      "dev": true,
+      "requires": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-languageserver-textdocument": "^1.0.3",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-nls": "^5.0.0",
+        "vscode-uri": "^3.0.3"
+      }
+    },
+    "vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "dev": true
+    },
+    "vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "dev": true
+    },
+    "vscode-nls": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz",
+      "integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==",
+      "dev": true
+    },
+    "vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true
     },
     "walker": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint": "8.57.0",
     "eslint-config-expo": "8.0.1",
     "eslint-config-prettier": "10.1.1",
+    "eslint-plugin-json": "^3.1.0",
     "eslint-plugin-prettier": "5.2.3",
     "prettier": "3.5.3",
     "snyk": "^1.1294.0",

--- a/sudokuru/Changelog.json
+++ b/sudokuru/Changelog.json
@@ -1,5 +1,15 @@
 [
   {
+    "version": "1.29.0",
+    "date": "#{date}#",
+    "summary": "Added initialize notes setting as a preview feature to be able to start a game with the notes already filled in.",
+    "preview features": [
+      "Added initialize notes setting to be able to start a game with the notes already filled in."
+    ],
+    "targets": ["web", "mobile", "desktop"],
+    "contributors": ["Thomas-Gallant"]
+  },
+  {
     "version": "1.28.3",
     "date": "February 13th, 2025",
     "summary": "Updated popup styling, removed outdated question mark popups, and fixed bug where popups would appear out of view.",

--- a/sudokuru/app/Api/Profile.ts
+++ b/sudokuru/app/Api/Profile.ts
@@ -10,6 +10,7 @@ type profileValue =
   | "highlightIdenticalValues"
   | "highlightRow"
   | "progressIndicator"
+  | "initializeNotes"
   | "previewMode"
   | "strategyHintOrder";
 
@@ -27,6 +28,7 @@ export const getProfile = async (): Promise<Profile> => {
     highlightRow: true,
     highlightIdenticalValues: true,
     progressIndicator: true,
+    initializeNotes: true,
     previewMode: false,
     strategyHintOrder: sudokuStrategyArray,
   };
@@ -75,6 +77,9 @@ export const setProfileValue = async (
       break;
     case "progressIndicator":
       value.progressIndicator = !value.progressIndicator;
+      break;
+    case "initializeNotes":
+      value.initializeNotes = !value.initializeNotes;
       break;
     case "previewMode":
       value.previewMode = !value.previewMode;

--- a/sudokuru/app/Api/Puzzle.Types.ts
+++ b/sudokuru/app/Api/Puzzle.Types.ts
@@ -62,6 +62,7 @@ export interface Profile {
   highlightRow: boolean;
   highlightColumn: boolean;
   progressIndicator: boolean;
+  initializeNotes: boolean;
   previewMode: boolean;
   strategyHintOrder: SudokuStrategy[];
 }

--- a/sudokuru/app/Api/Puzzles.ts
+++ b/sudokuru/app/Api/Puzzles.ts
@@ -17,8 +17,11 @@ import { SudokuStrategy } from "sudokuru";
  * @param strategies - new game can have subset of these strategies
  * @returns promise of puzzle JSON object
  */
-export const startGame = (difficulty: GameDifficulty): SudokuObjectProps => {
-  return returnGameOfDifficulty(difficulty);
+export const startGame = (
+  difficulty: GameDifficulty,
+  initializeNotes: boolean,
+): SudokuObjectProps => {
+  return returnGameOfDifficulty(difficulty, initializeNotes);
   // !uncomment below for dev testing
   // return returnGameOfDifficulty("dev");
 };

--- a/sudokuru/app/Api/Puzzles.ts
+++ b/sudokuru/app/Api/Puzzles.ts
@@ -15,6 +15,7 @@ import { SudokuStrategy } from "sudokuru";
  * Given a difficulty and an user auth token retrieves a random puzzle close to the difficulty that the user hasn't solved before
  * @param difficulty - difficulty number (between 0 and 1)
  * @param strategies - new game can have subset of these strategies
+ * @param initializeNotes - boolean to determine if notes should be initialized.
  * @returns promise of puzzle JSON object
  */
 export const startGame = (
@@ -23,7 +24,7 @@ export const startGame = (
 ): SudokuObjectProps => {
   return returnGameOfDifficulty(difficulty, initializeNotes);
   // !uncomment below for dev testing
-  // return returnGameOfDifficulty("dev");
+  // return returnGameOfDifficulty("dev", initializeNotes);
 };
 
 /**

--- a/sudokuru/app/Components/SudokuBoard/Core/Functions/DifficultyFunctions.ts
+++ b/sudokuru/app/Components/SudokuBoard/Core/Functions/DifficultyFunctions.ts
@@ -165,10 +165,11 @@ export const returnPuzzleOfDifficulty = (
  */
 export const returnGameOfDifficulty = (
   difficulty: GameDifficulty | "dev",
+  initializeNotes: boolean,
 ): SudokuObjectProps => {
   const puzzles = returnPuzzleOfDifficulty(difficulty);
   if (difficulty === "dev") {
     difficulty = "novice";
   }
-  return convertPuzzleToSudokuObject(puzzles, difficulty);
+  return convertPuzzleToSudokuObject(puzzles, difficulty, initializeNotes);
 };

--- a/sudokuru/app/Components/SudokuBoard/Core/Functions/DifficultyFunctions.ts
+++ b/sudokuru/app/Components/SudokuBoard/Core/Functions/DifficultyFunctions.ts
@@ -161,6 +161,7 @@ export const returnPuzzleOfDifficulty = (
 /**
  * This function takes in the requested difficulty and returns a puzzle matching the difficulty.
  * @param difficulty The difficulty classification of the puzzle. (string)
+ * @param initializeNotes Boolean to determine if notes should be initialized.
  * @returns A puzzle object that is readable by the Sudoku component.
  */
 export const returnGameOfDifficulty = (

--- a/sudokuru/app/Components/SudokuBoard/Core/Functions/GenerateGameFunctions.ts
+++ b/sudokuru/app/Components/SudokuBoard/Core/Functions/GenerateGameFunctions.ts
@@ -5,14 +5,16 @@ import { SudokuBoardProps } from "../../SudokuBoard";
 export async function generateGame(props: SudokuBoardProps) {
   let gameData = null;
 
+  const initializeNotes = true;
+
   if (props.action === "StartGame") {
-    return startGame(props.difficulty);
+    return startGame(props.difficulty, initializeNotes);
   } else if (props.action === "ResumeGame") {
     const gameData: SudokuObjectProps[] = await getGame();
     // If game object is not returned, you get redirected to Main Page
     if (gameData == null) {
       // If resume game data is invalid, we start a novice game
-      return startGame("novice");
+      return startGame("novice", initializeNotes);
     }
     return gameData[0];
   }

--- a/sudokuru/app/Components/SudokuBoard/Core/Functions/GenerateGameFunctions.ts
+++ b/sudokuru/app/Components/SudokuBoard/Core/Functions/GenerateGameFunctions.ts
@@ -2,10 +2,11 @@ import { getGame, startGame } from "../../../../Api/Puzzles";
 import { SudokuObjectProps } from "../../../../Functions/LocalDatabase";
 import { SudokuBoardProps } from "../../SudokuBoard";
 
-export async function generateGame(props: SudokuBoardProps) {
+export async function generateGame(
+  props: SudokuBoardProps,
+  initializeNotes: boolean,
+) {
   let gameData = null;
-
-  const initializeNotes = true;
 
   if (props.action === "StartGame") {
     return startGame(props.difficulty, initializeNotes);

--- a/sudokuru/app/Components/SudokuBoard/SudokuBoard.tsx
+++ b/sudokuru/app/Components/SudokuBoard/SudokuBoard.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { View } from "react-native";
 import {
   finishSudokuGame,

--- a/sudokuru/app/Components/SudokuBoard/SudokuBoard.tsx
+++ b/sudokuru/app/Components/SudokuBoard/SudokuBoard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { View } from "react-native";
 import {
   finishSudokuGame,
@@ -66,10 +66,21 @@ const SudokuBoard = (props: SudokuBoardProps) => {
 
   const [sudokuHint, setSudokuHint] = useState<HintObjectProps>();
 
-  const { strategyHintOrderSetting } = React.useContext(PreferencesContext);
+  const {
+    strategyHintOrderSetting,
+    featurePreviewSetting,
+    initializeNotesSetting,
+  } = React.useContext(PreferencesContext);
 
   useEffect(() => {
-    generateGame(props).then((game) => {
+    let initializeNotes = false;
+
+    // Enabling initialize notes is under feature preview
+    if (initializeNotesSetting && featurePreviewSetting) {
+      initializeNotes = true;
+    }
+
+    generateGame(props, initializeNotes).then((game) => {
       if (game == null) {
         return;
       }

--- a/sudokuru/app/Contexts/InitializeContext.ts
+++ b/sudokuru/app/Contexts/InitializeContext.ts
@@ -21,6 +21,9 @@ const InitializeContext = () => {
   const [progressIndicatorSetting, setProgressIndicatorSetting] =
     React.useState(true);
 
+  const [initializeNotesSetting, setInitializeNotesSetting] =
+    React.useState(true);
+
   const [featurePreviewSetting, setFeaturePreviewSetting] =
     React.useState(false);
 
@@ -38,6 +41,7 @@ const InitializeContext = () => {
       setFeaturePreviewSetting(data.previewMode);
       setStrategyHintOrderSetting(data.strategyHintOrder);
       setProgressIndicatorSetting(data.progressIndicator);
+      setInitializeNotesSetting(data.initializeNotes);
     });
   }, []);
 
@@ -89,6 +93,11 @@ const InitializeContext = () => {
     return setProgressIndicatorSetting(!progressIndicatorSetting);
   }, [progressIndicatorSetting]);
 
+  const toggleInitializeNotes = React.useCallback(() => {
+    setProfileValue("initializeNotes");
+    return setInitializeNotesSetting(!initializeNotesSetting);
+  }, [initializeNotesSetting]);
+
   const toggleFeaturePreview = React.useCallback(() => {
     setProfileValue("previewMode");
     return setFeaturePreviewSetting(!featurePreviewSetting);
@@ -121,6 +130,8 @@ const InitializeContext = () => {
       highlightColumnSetting,
       toggleProgressIndicator,
       progressIndicatorSetting,
+      toggleInitializeNotes,
+      initializeNotesSetting,
       toggleFeaturePreview,
       featurePreviewSetting,
       updateStrategyHintOrder,
@@ -143,6 +154,8 @@ const InitializeContext = () => {
       highlightColumnSetting,
       toggleProgressIndicator,
       progressIndicatorSetting,
+      toggleInitializeNotes,
+      initializeNotesSetting,
       toggleFeaturePreview,
       featurePreviewSetting,
       updateStrategyHintOrder,

--- a/sudokuru/app/Contexts/PreferencesContext.ts
+++ b/sudokuru/app/Contexts/PreferencesContext.ts
@@ -25,6 +25,8 @@ export const PreferencesContext = React.createContext({
   progressIndicatorSetting: true,
   toggleFeaturePreview: () => {},
   featurePreviewSetting: false,
+  toggleInitializeNotes: () => {},
+  initializeNotesSetting: true,
   updateStrategyHintOrder: (props: SudokuStrategy[]) => {},
   strategyHintOrderSetting: returnSudokuStrategyArray(),
 });

--- a/sudokuru/app/Functions/LocalDatabase.ts
+++ b/sudokuru/app/Functions/LocalDatabase.ts
@@ -70,7 +70,7 @@ export const convertPuzzleToSudokuObject = (
           type: "note",
           entry: notesToAdd,
         };
-      } catch (e) {
+      } catch {
         break;
       }
     }

--- a/sudokuru/app/Functions/LocalDatabase.ts
+++ b/sudokuru/app/Functions/LocalDatabase.ts
@@ -1,6 +1,7 @@
 import { GameDifficulty } from "../Components/SudokuBoard/Core/Functions/DifficultyFunctions";
 import { SUDOKU_STRATEGY_ARRAY, SudokuStrategy } from "sudokuru";
 import { z } from "zod";
+import { getSudokuHint } from "../Components/SudokuBoard/Core/Functions/HintFunctions";
 
 export interface InputPuzzle {
   p: string; // initial puzzle string
@@ -15,6 +16,7 @@ export interface InputPuzzle {
 export const convertPuzzleToSudokuObject = (
   puzzle: InputPuzzle,
   difficulty: GameDifficulty,
+  initializeNotes: boolean,
 ): SudokuObjectProps => {
   let game: SudokuObjectProps = {
     variant: "classic",
@@ -52,6 +54,28 @@ export const convertPuzzleToSudokuObject = (
       game.puzzleSolution[i][j] = numValueSolution;
     }
   }
+
+  // Initialize the board with notes filled in
+  if (initializeNotes) {
+    const ALL_NOTES = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+    while (true) {
+      try {
+        let hint = getSudokuHint(game.puzzle, game.puzzleSolution, [
+          "AMEND_NOTES",
+        ]);
+        const notesToAdd = ALL_NOTES.filter(
+          (x) => !hint.removals[0].slice(2).includes(x),
+        );
+        game.puzzle[hint.removals[0][0]][hint.removals[0][1]] = {
+          type: "note",
+          entry: notesToAdd,
+        };
+      } catch (e) {
+        break;
+      }
+    }
+  }
+
   // Return a clone here so that this is a clone.
   return JSON.parse(JSON.stringify(game));
 };

--- a/sudokuru/app/Functions/LocalDatabase.ts
+++ b/sudokuru/app/Functions/LocalDatabase.ts
@@ -63,6 +63,9 @@ export const convertPuzzleToSudokuObject = (
         let hint = getSudokuHint(game.puzzle, game.puzzleSolution, [
           "AMEND_NOTES",
         ]);
+        // hint.removals structure: [row, col, note1, note2, ...]
+        // slice(2) skips row and col to get just the notes to remove
+        // Filter to keep only notes that shouldn't be removed
         const notesToAdd = ALL_NOTES.filter(
           (x) => !hint.removals[0].slice(2).includes(x),
         );
@@ -71,6 +74,8 @@ export const convertPuzzleToSudokuObject = (
           entry: notesToAdd,
         };
       } catch {
+        // If getSudokuHint throws an exception, we've initialized
+        // all possible notes and can exit the loop
         break;
       }
     }

--- a/sudokuru/app/Pages/ProfilePage.tsx
+++ b/sudokuru/app/Pages/ProfilePage.tsx
@@ -153,22 +153,22 @@ const ProfilePage = () => {
             valueToggle={toggleProgressIndicator}
             testIdPrefix="ProgressIndicator"
           ></ProfileToggle>
-          {/* Initialize Notes is in feature preview as it's a new feature 
-            that may affect game statistics and difficulty perception */}
-          {featurePreviewSetting && (
-            <ProfileToggle
-              name="Initialize Notes"
-              value={initializeNotesSetting}
-              valueToggle={toggleInitializeNotes}
-              testIdPrefix="InitializeNotes"
-            ></ProfileToggle>
-          )}
           <ProfileToggle
             name="Feature Preview"
             value={featurePreviewSetting}
             valueToggle={toggleFeaturePreview}
             testIdPrefix="FeaturePreview"
           ></ProfileToggle>
+          {/* Initialize Notes is in feature preview as it's a new feature 
+            that may affect game statistics and difficulty perception */}
+          {featurePreviewSetting && (
+            <ProfileToggle
+              name="  Initialize Notes"
+              value={initializeNotesSetting}
+              valueToggle={toggleInitializeNotes}
+              testIdPrefix="InitializeNotes"
+            ></ProfileToggle>
+          )}
         </View>
         <View
           style={{

--- a/sudokuru/app/Pages/ProfilePage.tsx
+++ b/sudokuru/app/Pages/ProfilePage.tsx
@@ -30,6 +30,8 @@ const ProfilePage = () => {
     highlightRowSetting,
     progressIndicatorSetting,
     toggleProgressIndicator,
+    initializeNotesSetting,
+    toggleInitializeNotes,
     toggleFeaturePreview,
     featurePreviewSetting,
   } = React.useContext(PreferencesContext);
@@ -151,6 +153,14 @@ const ProfilePage = () => {
             valueToggle={toggleProgressIndicator}
             testIdPrefix="ProgressIndicator"
           ></ProfileToggle>
+          {featurePreviewSetting && (
+            <ProfileToggle
+              name="Initialize Notes"
+              value={initializeNotesSetting}
+              valueToggle={toggleInitializeNotes}
+              testIdPrefix="InitializeNotes"
+            ></ProfileToggle>
+          )}
           <ProfileToggle
             name="Feature Preview"
             value={featurePreviewSetting}

--- a/sudokuru/app/Pages/ProfilePage.tsx
+++ b/sudokuru/app/Pages/ProfilePage.tsx
@@ -153,6 +153,8 @@ const ProfilePage = () => {
             valueToggle={toggleProgressIndicator}
             testIdPrefix="ProgressIndicator"
           ></ProfileToggle>
+          {/* Initialize Notes is in feature preview as it's a new feature 
+            that may affect game statistics and difficulty perception */}
           {featurePreviewSetting && (
             <ProfileToggle
               name="Initialize Notes"


### PR DESCRIPTION
Changelog:
- Adding new toggle in feature preview to enable initialize notes setting which starts the game with the notes filled in
- Adding `eslint-plugin-json` because eslint was complaining about scanning the modified json files
- Adding useful helper functions and established pattern for playwright tests to determine the type of sudoku cell (empty, notes, value), which was not possible before. 
- Fixing a typo in one of the playwright test names

A future PR will determine how we will update statistics for the user to reflect this setting being turned on.

## Checklist for completing pull request:
- [x] Update Changelog.json if any functionality has been changed for the end user.
- [x] Test functionality on Mobile and Web
- [x] Verify that any tests for new functionality are created and functional.
- [x] SudokuBoard state should only directly be updated in SudokuBoard.tsx file (usage of setSudokuBoard() function)
- [x] If needed, update the Readme

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a preview “Initialize Notes” option in the user settings, allowing games to start with pre-filled notes.
	- The feature is available across multiple platforms (web, mobile, and desktop) and can be toggled directly from the profile page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->