### PR TITLE
Adding auto simplify notes toggle to feature preview

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -208,7 +208,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ [linux, ubuntu-latest], [windows, windows-latest] ]
+        platform: [ [linux, ubuntu-22.04], [windows, windows-latest] ]
     runs-on: ${{ matrix.platform[1] }}
     needs: [ code_scan, analyze ]
     steps:
@@ -222,7 +222,7 @@ jobs:
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable
       - name: install ubuntu dependencies
-        if: matrix.platform[1] == 'ubuntu-latest'
+        if: matrix.platform[1] == 'ubuntu-22.04'
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -208,7 +208,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ [linux, ubuntu-20.04], [windows, windows-latest] ]
+        platform: [ [linux, ubuntu-latest], [windows, windows-latest] ]
     runs-on: ${{ matrix.platform[1] }}
     needs: [ code_scan, analyze ]
     steps:
@@ -222,7 +222,7 @@ jobs:
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable
       - name: install ubuntu dependencies
-        if: matrix.platform[1] == 'ubuntu-20.04'
+        if: matrix.platform[1] == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf

--- a/e2e/web/data/hidden-pair-profile.json
+++ b/e2e/web/data/hidden-pair-profile.json
@@ -7,6 +7,7 @@
   "highlightIdenticalValues": true,
   "progressIndicator": true,
   "initializeNotes": true,
+  "simplifyNotes": true,
   "previewMode": false,
   "strategyHintOrder": [
     "HIDDEN_PAIR",

--- a/e2e/web/data/hidden-quadruplet-profile.json
+++ b/e2e/web/data/hidden-quadruplet-profile.json
@@ -7,6 +7,7 @@
   "highlightIdenticalValues": true,
   "progressIndicator": true,
   "initializeNotes": true,
+  "simplifyNotes": true,
   "previewMode": false,
   "strategyHintOrder": [
     "HIDDEN_QUADRUPLET",

--- a/e2e/web/data/hidden-single-profile.json
+++ b/e2e/web/data/hidden-single-profile.json
@@ -7,6 +7,7 @@
   "highlightIdenticalValues": true,
   "progressIndicator": true,
   "initializeNotes": true,
+  "simplifyNotes": true,
   "previewMode": false,
   "strategyHintOrder": [
     "HIDDEN_SINGLE",

--- a/e2e/web/data/hidden-triplet-profile.json
+++ b/e2e/web/data/hidden-triplet-profile.json
@@ -7,6 +7,7 @@
   "highlightIdenticalValues": true,
   "progressIndicator": true,
   "initializeNotes": true,
+  "simplifyNotes": true,
   "previewMode": false,
   "strategyHintOrder": [
     "HIDDEN_TRIPLET",

--- a/e2e/web/data/obvious-pair-profile.json
+++ b/e2e/web/data/obvious-pair-profile.json
@@ -7,6 +7,7 @@
   "highlightIdenticalValues": true,
   "progressIndicator": true,
   "initializeNotes": true,
+  "simplifyNotes": true,
   "previewMode": false,
   "strategyHintOrder": [
     "OBVIOUS_PAIR",

--- a/e2e/web/data/obvious-quadruplet-profile.json
+++ b/e2e/web/data/obvious-quadruplet-profile.json
@@ -7,6 +7,7 @@
   "highlightIdenticalValues": true,
   "progressIndicator": true,
   "initializeNotes": true,
+  "simplifyNotes": true,
   "previewMode": false,
   "strategyHintOrder": [
     "OBVIOUS_QUADRUPLET",

--- a/e2e/web/data/obvious-triplet-profile.json
+++ b/e2e/web/data/obvious-triplet-profile.json
@@ -7,6 +7,7 @@
   "highlightIdenticalValues": true,
   "progressIndicator": true,
   "initializeNotes": true,
+  "simplifyNotes": true,
   "previewMode": false,
   "strategyHintOrder": [
     "OBVIOUS_TRIPLET",

--- a/e2e/web/data/pointing-pair-profile.json
+++ b/e2e/web/data/pointing-pair-profile.json
@@ -7,6 +7,7 @@
   "highlightIdenticalValues": true,
   "progressIndicator": true,
   "initializeNotes": true,
+  "simplifyNotes": true,
   "previewMode": false,
   "strategyHintOrder": [
     "POINTING_PAIR",

--- a/e2e/web/data/pointing-triplet-profile.json
+++ b/e2e/web/data/pointing-triplet-profile.json
@@ -7,6 +7,7 @@
   "highlightIdenticalValues": true,
   "progressIndicator": true,
   "initializeNotes": true,
+  "simplifyNotes": true,
   "previewMode": false,
   "strategyHintOrder": [
     "POINTING_TRIPLET",

--- a/e2e/web/data/progress-indicator-disabled-profile.json
+++ b/e2e/web/data/progress-indicator-disabled-profile.json
@@ -6,6 +6,8 @@
   "highlightRow": true,
   "highlightIdenticalValues": true,
   "progressIndicator": false,
+  "initializeNotes": true,
+  "simplifyNotes": true,
   "previewMode": false,
   "strategyHintOrder": [
     "OBVIOUS_SINGLE",

--- a/e2e/web/page/profile.page.ts
+++ b/e2e/web/page/profile.page.ts
@@ -22,6 +22,8 @@ export class ProfilePage {
   readonly featurePreviewSwitchDisabled: Locator;
   readonly initializeNotesSwitchEnabled: Locator;
   readonly initializeNotesSwitchDisabled: Locator;
+  readonly simplifyNotesSwitchEnabled: Locator;
+  readonly simplifyNotesSwitchDisabled: Locator;
 
   readonly hintStrategyMenuUp: Locator;
   readonly hintStrategyMenuDown: Locator;
@@ -62,6 +64,10 @@ export class ProfilePage {
     );
     this.initializeNotesSwitchDisabled = page.getByTestId(
       "InitializeNotesDisabled",
+    );
+    this.simplifyNotesSwitchEnabled = page.getByTestId("SimplifyNotesEnabled");
+    this.simplifyNotesSwitchDisabled = page.getByTestId(
+      "SimplifyNotesDisabled",
     );
 
     this.hintStrategyMenuUp = page.getByTestId("HintStrategyMenuUp");

--- a/e2e/web/specs/board-buttons-and-shortcuts.spec.ts
+++ b/e2e/web/specs/board-buttons-and-shortcuts.spec.ts
@@ -247,6 +247,29 @@ test.describe("Simplify Notes", () => {
     await sudokuBoard.cellHasContent(0, 5, "568", "notes");
   });
 
+  test("should simplify notes after an incorrect then correct value insertion when enabled", async ({
+    resumeGame,
+  }) => {
+    const headerComponent = new HeaderComponent(resumeGame);
+    await headerComponent.profile.click();
+    const profilePage = new ProfilePage(resumeGame);
+    await profilePage.featurePreviewSwitchDisabled.click();
+    await expect(profilePage.initializeNotesSwitchEnabled).toBeInViewport({
+      ratio: 1,
+    });
+    await profilePage.initializeNotesSwitchEnabled.click();
+    await profilePage.initializeNotesSwitchDisabled.click();
+    await headerComponent.drawer.click();
+    await headerComponent.drawerPlay.click();
+    const playPage = new PlayPage(resumeGame);
+    await playPage.resume.click();
+    const sudokuBoard = new SudokuBoardComponent(resumeGame);
+    await sudokuBoard.cell[0][0].click();
+    await sudokuBoard.cell[0][0].press("2");
+    await sudokuBoard.cell[0][0].press("1");
+    await sudokuBoard.cellHasContent(0, 5, "568", "notes");
+  });
+
   test("should not simplify notes after incorrect value insertion when enabled", async ({
     resumeGame,
   }) => {

--- a/e2e/web/specs/board-buttons-and-shortcuts.spec.ts
+++ b/e2e/web/specs/board-buttons-and-shortcuts.spec.ts
@@ -4,6 +4,7 @@ import { PlayPage } from "../page/play.page";
 import {
   AMEND_NOTES_EMPTY_CELL_GAME,
   NEW_EMPTY_GAME,
+  OBVIOUS_SINGLE_GAME,
   PROGRESS_INDICATOR_DISABLED_PROFILE,
 } from "../data";
 import { getSingleMultiSelectKey } from "../playwright.config";
@@ -219,6 +220,62 @@ test.describe("Initialize Notes", () => {
     await sudokuBoardComponent.verifyAllCellsInBoard(async (r, c) => {
       await sudokuBoardComponent.cellIsNotNote(r, c);
     });
+  });
+});
+
+test.describe("Simplify Notes", () => {
+  test.use({ gameToResume: OBVIOUS_SINGLE_GAME });
+  test("should simplify notes after correct value insertion when enabled", async ({
+    resumeGame,
+  }) => {
+    const headerComponent = new HeaderComponent(resumeGame);
+    await headerComponent.profile.click();
+    const profilePage = new ProfilePage(resumeGame);
+    await profilePage.featurePreviewSwitchDisabled.click();
+    await expect(profilePage.initializeNotesSwitchEnabled).toBeInViewport({
+      ratio: 1,
+    });
+    await profilePage.initializeNotesSwitchEnabled.click();
+    await profilePage.initializeNotesSwitchDisabled.click();
+    await headerComponent.drawer.click();
+    await headerComponent.drawerPlay.click();
+    const playPage = new PlayPage(resumeGame);
+    await playPage.resume.click();
+    const sudokuBoard = new SudokuBoardComponent(resumeGame);
+    await sudokuBoard.cell[0][0].click();
+    await sudokuBoard.cell[0][0].press("1");
+    await sudokuBoard.cellHasContent(0, 5, "568", "notes");
+  });
+
+  test("should not simplify notes after incorrect value insertion when enabled", async ({
+    resumeGame,
+  }) => {
+    const headerComponent = new HeaderComponent(resumeGame);
+    await headerComponent.profile.click();
+    const profilePage = new ProfilePage(resumeGame);
+    await profilePage.featurePreviewSwitchDisabled.click();
+    await expect(profilePage.initializeNotesSwitchEnabled).toBeInViewport({
+      ratio: 1,
+    });
+    await profilePage.initializeNotesSwitchEnabled.click();
+    await profilePage.initializeNotesSwitchDisabled.click();
+    await headerComponent.drawer.click();
+    await headerComponent.drawerPlay.click();
+    const playPage = new PlayPage(resumeGame);
+    await playPage.resume.click();
+    const sudokuBoard = new SudokuBoardComponent(resumeGame);
+    await sudokuBoard.cell[0][0].click();
+    await sudokuBoard.cell[0][0].press("2");
+    await sudokuBoard.cellHasContent(0, 5, "1568", "notes");
+  });
+
+  test("should not simplify notes after correct value insertion when disabled", async ({
+    resumeGame,
+  }) => {
+    const sudokuBoard = new SudokuBoardComponent(resumeGame);
+    await sudokuBoard.cell[0][0].click();
+    await sudokuBoard.cell[0][0].press("1");
+    await sudokuBoard.cellHasContent(0, 5, "1568", "notes");
   });
 });
 

--- a/e2e/web/specs/board-buttons-and-shortcuts.spec.ts
+++ b/e2e/web/specs/board-buttons-and-shortcuts.spec.ts
@@ -245,6 +245,18 @@ test.describe("Simplify Notes", () => {
     await sudokuBoard.cell[0][0].click();
     await sudokuBoard.cell[0][0].press("1");
     await sudokuBoard.cellHasContent(0, 5, "568", "notes");
+
+    await sudokuBoard.cellHasContent(2, 4, "13456", "notes");
+    await sudokuBoard.cellHasContent(2, 5, "13456", "notes");
+    await sudokuBoard.cellHasContent(5, 6, "12579", "notes");
+    await sudokuBoard.cellHasContent(5, 7, "123579", "notes");
+    await sudokuBoard.cellHasContent(7, 4, "13468", "notes");
+    await sudokuBoard.cellHasContent(7, 5, "13468", "notes");
+    await sudokuBoard.cellHasContent(7, 6, "124678", "notes");
+    await sudokuBoard.cellHasContent(7, 7, "12367", "notes");
+    await sudokuBoard.cellHasContent(8, 5, "134568", "notes");
+    await sudokuBoard.cellHasContent(8, 6, "146789", "notes");
+    await sudokuBoard.cellHasContent(8, 7, "13679", "notes");
   });
 
   test("should simplify notes after an incorrect then correct value insertion when enabled", async ({

--- a/e2e/web/specs/feature-preview.spec.ts
+++ b/e2e/web/specs/feature-preview.spec.ts
@@ -45,4 +45,25 @@ test.describe("feature preview", () => {
       ratio: 1,
     });
   });
+
+  test("Simplify Notes profile setting appears in feature preview", async ({
+    featurePreview,
+  }) => {
+    const profilePage = new ProfilePage(featurePreview);
+    await expect(profilePage.simplifyNotesSwitchEnabled).toBeInViewport({
+      ratio: 1,
+    });
+  });
+
+  test("Simplify Notes profile setting does not appear when feature preview is disabled", async ({
+    profile,
+  }) => {
+    const profilePage = new ProfilePage(profile);
+    await expect(profilePage.simplifyNotesSwitchDisabled).not.toBeInViewport({
+      ratio: 1,
+    });
+    await expect(profilePage.simplifyNotesSwitchEnabled).not.toBeInViewport({
+      ratio: 1,
+    });
+  });
 });

--- a/e2e/web/specs/hints.spec.ts
+++ b/e2e/web/specs/hints.spec.ts
@@ -48,6 +48,10 @@ import {
   NOT_HIGHLIGHTED_COLOR_RGB,
   SELECTED_COLOR_RGB,
 } from "../../../sudokuru/app/Styling/HighlightColors";
+import { ProfilePage } from "../page/profile.page";
+import { HeaderComponent } from "../components/header.component";
+import { PlayPage } from "../page/play.page";
+import { expect } from "@playwright/test";
 
 test.describe("hint mode operates correctly", () => {
   test.use({ gameToResume: AMEND_NOTES_EMPTY_CELL_GAME });
@@ -294,6 +298,38 @@ test.describe("board OBVIOUS_SINGLE", () => {
       [{ contentType: "notes", content: "1", row: 0, column: 0 }],
       [{ contentType: "value", content: "1", row: 0, column: 0 }],
     );
+  });
+
+  test("OBVIOUS_SINGLE with simplify notes enabled", async ({ resumeGame }) => {
+    const headerComponent = new HeaderComponent(resumeGame);
+    await headerComponent.profile.click();
+    const profilePage = new ProfilePage(resumeGame);
+    await profilePage.featurePreviewSwitchDisabled.click();
+    await expect(profilePage.initializeNotesSwitchEnabled).toBeInViewport({
+      ratio: 1,
+    });
+    await profilePage.initializeNotesSwitchEnabled.click();
+    await profilePage.initializeNotesSwitchDisabled.click();
+    await headerComponent.drawer.click();
+    await headerComponent.drawerPlay.click();
+    const playPage = new PlayPage(resumeGame);
+    await playPage.resume.click();
+    const sudokuBoard = new SudokuBoardComponent(resumeGame);
+    await sudokuBoard.solveHint();
+    await sudokuBoard.cellHasContent(0, 5, "568", "notes");
+  });
+
+  test("OBVIOUS_SINGLE with simplify notes disabled", async ({
+    resumeGame,
+  }) => {
+    const headerComponent = new HeaderComponent(resumeGame);
+    await headerComponent.drawer.click();
+    await headerComponent.drawerPlay.click();
+    const playPage = new PlayPage(resumeGame);
+    await playPage.resume.click();
+    const sudokuBoard = new SudokuBoardComponent(resumeGame);
+    await sudokuBoard.solveHint();
+    await sudokuBoard.cellHasContent(0, 5, "1568", "notes");
   });
 });
 

--- a/sudokuru/Changelog.json
+++ b/sudokuru/Changelog.json
@@ -1,5 +1,15 @@
 [
   {
+    "version": "1.30.0",
+    "date": "#{date}#",
+    "summary": "Added simplify notes setting as a preview feature to auto simplify notes after value has been correctly inserted.",
+    "preview features": [
+      "Added simplify notes setting to auto simplify notes after value has been correctly inserted."
+    ],
+    "targets": ["web", "mobile", "desktop"],
+    "contributors": ["Thomas-Gallant"]
+  },
+  {
     "version": "1.29.1",
     "date": "March 20th, 2025",
     "summary": "Fixed a rare issue where clicking on a cell would not register the selection.",

--- a/sudokuru/app/Api/Profile.ts
+++ b/sudokuru/app/Api/Profile.ts
@@ -11,6 +11,7 @@ type profileValue =
   | "highlightRow"
   | "progressIndicator"
   | "initializeNotes"
+  | "simplifyNotes"
   | "previewMode"
   | "strategyHintOrder";
 
@@ -29,6 +30,7 @@ export const getProfile = async (): Promise<Profile> => {
     highlightIdenticalValues: true,
     progressIndicator: true,
     initializeNotes: true,
+    simplifyNotes: true,
     previewMode: false,
     strategyHintOrder: sudokuStrategyArray,
   };
@@ -80,6 +82,9 @@ export const setProfileValue = async (
       break;
     case "initializeNotes":
       value.initializeNotes = !value.initializeNotes;
+      break;
+    case "simplifyNotes":
+      value.simplifyNotes = !value.simplifyNotes;
       break;
     case "previewMode":
       value.previewMode = !value.previewMode;

--- a/sudokuru/app/Api/Puzzle.Types.ts
+++ b/sudokuru/app/Api/Puzzle.Types.ts
@@ -63,6 +63,7 @@ export interface Profile {
   highlightColumn: boolean;
   progressIndicator: boolean;
   initializeNotes: boolean;
+  simplifyNotes: boolean;
   previewMode: boolean;
   strategyHintOrder: SudokuStrategy[];
 }

--- a/sudokuru/app/Components/SudokuBoard/SudokuBoard.tsx
+++ b/sudokuru/app/Components/SudokuBoard/SudokuBoard.tsx
@@ -287,6 +287,7 @@ const SudokuBoard = (props: SudokuBoardProps) => {
       });
 
       // Simplify Notes if setting is enabled and value is correct
+      // This isn't the most performant way to do this but it is easy to read
       if (
         simplifyNotesSetting &&
         currentType === "note" &&

--- a/sudokuru/app/Components/SudokuBoard/SudokuBoard.tsx
+++ b/sudokuru/app/Components/SudokuBoard/SudokuBoard.tsx
@@ -288,6 +288,7 @@ const SudokuBoard = (props: SudokuBoardProps) => {
 
       // Simplify Notes if setting is enabled and value is correct
       // This isn't the most performant way to do this but it is easy to read
+      // We are looping through a bunch of cells we don't need to loop through
       if (
         simplifyNotesSetting &&
         currentType === "note" &&

--- a/sudokuru/app/Components/SudokuBoard/SudokuBoard.tsx
+++ b/sudokuru/app/Components/SudokuBoard/SudokuBoard.tsx
@@ -292,7 +292,6 @@ const SudokuBoard = (props: SudokuBoardProps) => {
       if (
         simplifyNotesSetting &&
         featurePreviewSetting &&
-        currentType === "note" &&
         !sudokuBoard.inNoteMode &&
         isValueCorrect(sudokuBoard.puzzleSolution[r][c], inputValue)
       ) {

--- a/sudokuru/app/Components/SudokuBoard/SudokuBoard.tsx
+++ b/sudokuru/app/Components/SudokuBoard/SudokuBoard.tsx
@@ -291,6 +291,7 @@ const SudokuBoard = (props: SudokuBoardProps) => {
       // We are looping through a bunch of cells we don't need to loop through
       if (
         simplifyNotesSetting &&
+        featurePreviewSetting &&
         currentType === "note" &&
         !sudokuBoard.inNoteMode &&
         isValueCorrect(sudokuBoard.puzzleSolution[r][c], inputValue)
@@ -809,7 +810,7 @@ const SudokuBoard = (props: SudokuBoardProps) => {
       // Remove unnecessary notes due to OBVIOUS_SINGLE hint
       // This isn't the most performant way to do this but it is easy to read
       // We are looping through a bunch of cells we don't need to loop through
-      if (simplifyNotesSetting) {
+      if (simplifyNotesSetting && featurePreviewSetting) {
         for (const [rowIndex, row] of sudokuBoard.puzzle.entries()) {
           for (const [columnIndex, cell] of row.entries()) {
             if (!(r === rowIndex && c === columnIndex)) {

--- a/sudokuru/app/Components/SudokuBoard/SudokuBoard.tsx
+++ b/sudokuru/app/Components/SudokuBoard/SudokuBoard.tsx
@@ -336,8 +336,6 @@ const SudokuBoard = (props: SudokuBoardProps) => {
       return;
     }
 
-    console.log(newActionHistory);
-
     // Storing old value in actionHistory
     sudokuBoard.actionHistory.push(newActionHistory);
 

--- a/sudokuru/app/Contexts/InitializeContext.ts
+++ b/sudokuru/app/Contexts/InitializeContext.ts
@@ -24,6 +24,8 @@ const InitializeContext = () => {
   const [initializeNotesSetting, setInitializeNotesSetting] =
     React.useState(true);
 
+  const [simplifyNotesSetting, setSimplifyNotesSetting] = React.useState(true);
+
   const [featurePreviewSetting, setFeaturePreviewSetting] =
     React.useState(false);
 
@@ -42,6 +44,7 @@ const InitializeContext = () => {
       setStrategyHintOrderSetting(data.strategyHintOrder);
       setProgressIndicatorSetting(data.progressIndicator);
       setInitializeNotesSetting(data.initializeNotes);
+      setSimplifyNotesSetting(data.simplifyNotes);
     });
   }, []);
 
@@ -98,6 +101,11 @@ const InitializeContext = () => {
     return setInitializeNotesSetting(!initializeNotesSetting);
   }, [initializeNotesSetting]);
 
+  const toggleSimplifyNotes = React.useCallback(() => {
+    setProfileValue("simplifyNotes");
+    return setSimplifyNotesSetting(!simplifyNotesSetting);
+  }, [simplifyNotesSetting]);
+
   const toggleFeaturePreview = React.useCallback(() => {
     setProfileValue("previewMode");
     return setFeaturePreviewSetting(!featurePreviewSetting);
@@ -132,6 +140,8 @@ const InitializeContext = () => {
       progressIndicatorSetting,
       toggleInitializeNotes,
       initializeNotesSetting,
+      toggleSimplifyNotes,
+      simplifyNotesSetting,
       toggleFeaturePreview,
       featurePreviewSetting,
       updateStrategyHintOrder,
@@ -156,6 +166,8 @@ const InitializeContext = () => {
       progressIndicatorSetting,
       toggleInitializeNotes,
       initializeNotesSetting,
+      toggleSimplifyNotes,
+      simplifyNotesSetting,
       toggleFeaturePreview,
       featurePreviewSetting,
       updateStrategyHintOrder,

--- a/sudokuru/app/Contexts/PreferencesContext.ts
+++ b/sudokuru/app/Contexts/PreferencesContext.ts
@@ -27,6 +27,8 @@ export const PreferencesContext = React.createContext({
   featurePreviewSetting: false,
   toggleInitializeNotes: () => {},
   initializeNotesSetting: true,
+  toggleSimplifyNotes: () => {},
+  simplifyNotesSetting: true,
   updateStrategyHintOrder: (props: SudokuStrategy[]) => {},
   strategyHintOrderSetting: returnSudokuStrategyArray(),
 });

--- a/sudokuru/app/Functions/LocalDatabase.ts
+++ b/sudokuru/app/Functions/LocalDatabase.ts
@@ -240,6 +240,8 @@ export const ProfileSchema = z.object({
   highlightIdenticalValues: z.boolean(),
   progressIndicator: z.boolean(),
   previewMode: z.boolean(),
+  initializeNotes: z.boolean(),
+  simplifyNotes: z.boolean(),
   strategyHintOrder: z.array(
     z.enum(Object.values(SUDOKU_STRATEGY_ARRAY) as [string, ...string[]]),
   ),

--- a/sudokuru/app/Pages/ProfilePage.tsx
+++ b/sudokuru/app/Pages/ProfilePage.tsx
@@ -32,6 +32,8 @@ const ProfilePage = () => {
     toggleProgressIndicator,
     initializeNotesSetting,
     toggleInitializeNotes,
+    simplifyNotesSetting,
+    toggleSimplifyNotes,
     toggleFeaturePreview,
     featurePreviewSetting,
   } = React.useContext(PreferencesContext);
@@ -167,6 +169,16 @@ const ProfilePage = () => {
               value={initializeNotesSetting}
               valueToggle={toggleInitializeNotes}
               testIdPrefix="InitializeNotes"
+            ></ProfileToggle>
+          )}
+          {/* Initialize Notes is in feature preview as it's a new feature 
+            that may affect game statistics and difficulty perception */}
+          {featurePreviewSetting && (
+            <ProfileToggle
+              name="  Simplify Notes"
+              value={simplifyNotesSetting}
+              valueToggle={toggleSimplifyNotes}
+              testIdPrefix="SimplifyNotes"
             ></ProfileToggle>
           )}
         </View>

--- a/sudokuru/app/Pages/ProfilePage.tsx
+++ b/sudokuru/app/Pages/ProfilePage.tsx
@@ -171,7 +171,7 @@ const ProfilePage = () => {
               testIdPrefix="InitializeNotes"
             ></ProfileToggle>
           )}
-          {/* Initialize Notes is in feature preview as it's a new feature 
+          {/* Simplify Notes is in feature preview as it's a new feature 
             that may affect game statistics and difficulty perception */}
           {featurePreviewSetting && (
             <ProfileToggle


### PR DESCRIPTION
Adding auto simplify notes toggle to feature preview.
A future PR will determine how we will update statistics for the user to reflect this setting being turned on.

Updating ubuntu image for linux build because 22.04 is no longer available and LTS

## Checklist for completing pull request:
- [x] Update Changelog.json if any functionality has been changed for the end user.
- [x] Test functionality on Mobile and Web
- [x] Verify that any tests for new functionality are created and functional.
- [x] SudokuBoard state should only directly be updated in SudokuBoard.tsx file (usage of setSudokuBoard() function)
- [x] If needed, update the Readme

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a "Simplify Notes" setting that automatically removes obsolete notes from related cells when a correct value is entered or placed via hints.
  - Added a toggle for the "Simplify Notes" feature in the profile settings, visible when feature preview is enabled.
- **Bug Fixes**
  - None.
- **Tests**
  - Added new tests to verify the behavior and UI visibility of the "Simplify Notes" setting and its impact on note simplification during gameplay and hints.
- **Documentation**
  - Updated changelog to include the new "Simplify Notes" feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->