### PR TITLE
feat: centralize theming and add light/dark modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,50 @@
 
 </details>
 
+## 🎨 Theme Architecture
+
+All application colors are defined in `sudokuru/app/Styling/theme.ts`. Three themes are
+available:
+
+| Theme name | Description |
+|------------|-------------|
+| `classic`  | Original teal/gold style |
+| `light`    | Newspaper style with dark text on light background |
+| `dark`     | Traditional dark mode |
+
+Each theme exposes the following color tokens:
+
+| Token | Purpose |
+|-------|---------|
+| `bg` | Application background |
+| `surface` | Card and surface backgrounds |
+| `surfaceAlt` | Alternate surface |
+| `text` | Primary text |
+| `textMuted` | Muted text |
+| `border` | Borders and dividers |
+| `accent`/`primary` | Accent elements and buttons |
+| `danger`/`warn`/`success` | Status colors |
+| `overlay` | Backdrops and overlays |
+| `focus` | Focus outlines |
+| `selection` | Selected state |
+
+To add a new theme:
+
+1. Define the theme in `sudokuru/app/Styling/theme.ts` with the tokens above.
+2. Export the theme via the `themes` object.
+3. The new theme will be automatically available in the `ThemeProvider` and can be
+   cycled using the Profile page control.
+
+### Linting for color literals
+
+Run `npm run lint:colors` to ensure no hard coded colors exist outside the styling
+directory.
+
+### Theme tests
+
+End‑to‑end tests verifying the theme system live under `e2e/web/specs/theme.spec.ts` and
+can be executed with `npm run playwright:test`.
+
 <details>
 <summary>docs</summary>
 

--- a/e2e/web/page/profile.page.ts
+++ b/e2e/web/page/profile.page.ts
@@ -6,8 +6,6 @@ export class ProfilePage {
   readonly page: Page;
   readonly title: Locator;
   readonly learnedLessons: Locator;
-  readonly themeSwitchEnabled: Locator;
-  readonly themeSwitchDisabled: Locator;
   readonly highlightSwitchEnabled: Locator;
   readonly highlightSwitchDisabled: Locator;
   readonly highlightIdenticalValuesSwitchEnabled: Locator;
@@ -33,8 +31,6 @@ export class ProfilePage {
     this.page = page;
     this.title = page.getByText("Profile");
     this.learnedLessons = page.getByTestId("LearnedLessons");
-    this.themeSwitchEnabled = page.getByTestId("DarkThemeEnabled");
-    this.themeSwitchDisabled = page.getByTestId("DarkThemeDisabled");
     this.highlightSwitchEnabled = page.getByTestId("HighlightEnabled");
     this.highlightSwitchDisabled = page.getByTestId("HighlightDisabled");
     this.highlightIdenticalValuesSwitchEnabled = page.getByTestId(

--- a/e2e/web/specs/profile.spec.ts
+++ b/e2e/web/specs/profile.spec.ts
@@ -1,26 +1,12 @@
 import { ProfilePage } from "../page/profile.page";
 import { test } from "../fixture";
 import { expect } from "@playwright/test";
-import {
-  GOLD_COLOR_RGB,
-  PURPLE_COLOR_RGB,
-} from "../../../sudokuru/app/Styling/HighlightColors";
 import { HeaderComponent } from "../components/header.component";
 import { returnSudokuStrategyArray } from "../../../sudokuru/app/Contexts/PreferencesContext";
 
 const SUDOKU_STRATEGY_ARRAY = returnSudokuStrategyArray();
 
 test.describe("profile", () => {
-  test("should toggle the theme and verify title color change", async ({
-    profile,
-  }) => {
-    const profilePage = new ProfilePage(profile);
-    const title = profile.getByText("Profile");
-    await expect(title).toHaveCSS("color", GOLD_COLOR_RGB);
-    await profilePage.themeSwitchEnabled.click();
-    await expect(title).toHaveCSS("color", PURPLE_COLOR_RGB);
-  });
-
   test("should toggle root highlight and verify all highlight switches' states", async ({
     profile,
   }) => {

--- a/e2e/web/specs/theme.spec.ts
+++ b/e2e/web/specs/theme.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from "../fixture";
+import { themes } from "../../../sudokuru/app/Styling/theme";
+
+const toRgb = (hex: string) => {
+  const n = parseInt(hex.replace("#", ""), 16);
+  const r = (n >> 16) & 255;
+  const g = (n >> 8) & 255;
+  const b = n & 255;
+  return `rgb(${r}, ${g}, ${b})`;
+};
+
+test.describe("theme", () => {
+  test("toggle cycles themes and persists", async ({ profile }) => {
+    const toggle = profile.getByTestId("ThemeToggle");
+    const getTheme = () =>
+      profile.evaluate(() => document.documentElement.dataset.theme);
+
+    await expect(await getTheme()).toBe("classic");
+    await toggle.click();
+    await expect(await getTheme()).toBe("light");
+    await toggle.click();
+    await expect(await getTheme()).toBe("dark");
+    await toggle.click();
+    await expect(await getTheme()).toBe("classic");
+    await profile.reload();
+    await expect(await getTheme()).toBe("classic");
+  });
+
+  test("applies token colors", async ({ profile }) => {
+    const toggle = profile.getByTestId("ThemeToggle");
+    await toggle.click(); // switch to light
+    const root = profile.getByTestId("AppRoot");
+    await expect(root).toHaveCSS(
+      "background-color",
+      toRgb(themes.light.colors.bg),
+    );
+    const title = profile.getByText("Profile");
+    await expect(title).toHaveCSS("color", toRgb(themes.light.colors.accent));
+  });
+
+  test("focus is visible", async ({ profile }) => {
+    const toggle = profile.getByTestId("ThemeToggle");
+    await toggle.focus();
+    await expect(toggle).toBeFocused();
+    const outline = await profile.evaluate(() => {
+      const el = document.querySelector(
+        '[data-testid="ThemeToggle"]',
+      ) as HTMLElement;
+      const style = getComputedStyle(el);
+      return style.outlineStyle || style.boxShadow;
+    });
+    expect(outline).not.toBe("none");
+  });
+});

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "snyk:opensource": "npx snyk test --all-projects --exclude=.vercel --org=sudokuru",
     "snyk:code": "npx snyk code test --org=sudokuru",
     "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "lint:fix": "eslint . --fix",
+    "lint:colors": "node scripts/lint-colors.js"
   },
   "devDependencies": {
     "eslint": "9.27.0",

--- a/scripts/lint-colors.js
+++ b/scripts/lint-colors.js
@@ -1,0 +1,16 @@
+const { execSync } = require('child_process');
+const pattern = "(#[0-9a-fA-F]{3,8}|(?:rgb|hsl)a?\\(|'(?:white|black|red|blue|green|gray|grey|yellow|orange|pink)'|\"(?:white|black|red|blue|green|gray|grey|yellow|orange|pink)\")";
+try {
+  const cmd = `rg --no-heading -n ${JSON.stringify(pattern)} sudokuru/app | grep -v 'sudokuru/app/Styling'`;
+  const result = execSync(cmd, { stdio: 'pipe', shell: '/bin/bash' }).toString();
+  if (result.trim().length > 0) {
+    console.error(result);
+    process.exit(1);
+  }
+} catch (e) {
+  if (e.status === 1 && (!e.stdout || e.stdout.toString().trim() === '')) {
+    process.exit(0);
+  }
+  console.error(e.stdout?.toString() || e.message);
+  process.exit(1);
+}

--- a/sudokuru/app/Api/Theme.ts
+++ b/sudokuru/app/Api/Theme.ts
@@ -1,0 +1,12 @@
+import { getKeyJSON, storeData } from "../Functions/AsyncStorage";
+
+const THEME_KEY = "theme";
+
+export const getStoredTheme = async (): Promise<string | undefined> => {
+  const value = await getKeyJSON(THEME_KEY);
+  return value ?? undefined;
+};
+
+export const setStoredTheme = async (name: string) => {
+  await storeData(THEME_KEY, JSON.stringify(name));
+};

--- a/sudokuru/app/App.tsx
+++ b/sudokuru/app/App.tsx
@@ -2,22 +2,19 @@ import "@expo/metro-runtime"; // web fast refresh for development
 import "react-native-gesture-handler"; // This needs to be at top to work
 import * as React from "react";
 import { PreferencesContext } from "./Contexts/PreferencesContext";
-import { Provider as PaperProvider } from "react-native-paper";
-import { NavigationContainer } from "@react-navigation/native";
 import InitializeContext from "./Contexts/InitializeContext";
 import DrawerNavigator from "./Navigation/DrawerNavigator";
+import { ThemeProvider } from "./Contexts/ThemeContext";
 import { registerRootComponent } from "expo";
 
 function App() {
-  const { theme, preferences } = InitializeContext();
+  const { preferences } = InitializeContext();
 
   return (
     <PreferencesContext.Provider value={preferences}>
-      <PaperProvider theme={theme}>
-        <NavigationContainer theme={theme}>
-          <DrawerNavigator />
-        </NavigationContainer>
-      </PaperProvider>
+      <ThemeProvider>
+        <DrawerNavigator />
+      </ThemeProvider>
     </PreferencesContext.Provider>
   );
 }

--- a/sudokuru/app/Components/Header.tsx
+++ b/sudokuru/app/Components/Header.tsx
@@ -5,18 +5,15 @@ import { Image, Pressable, View, useWindowDimensions } from "react-native";
 import HomeButton from "./Home/HomeButton";
 import { useNavigation } from "@react-navigation/native";
 import { PreferencesContext } from "../Contexts/PreferencesContext";
-import { IconButton, Text, useTheme } from "react-native-paper";
+import { IconButton, Text } from "react-native-paper";
+import { useTheme } from "../Contexts/ThemeContext";
 
 const Header = () => {
   const navigation: any = useNavigation();
-  const theme = useTheme();
+  const { themeName, theme } = useTheme();
 
-  const {
-    darkThemeSetting,
-    currentPage,
-    updateCurrentPage,
-    featurePreviewSetting,
-  } = React.useContext(PreferencesContext);
+  const { currentPage, updateCurrentPage, featurePreviewSetting } =
+    React.useContext(PreferencesContext);
 
   const size = useWindowDimensions();
   const minSize = Math.min(size.width, size.height);
@@ -25,7 +22,7 @@ const Header = () => {
   const DARK_LOGO = require("../../.assets/goldLogoText.png");
   const LIGHT_LOGO = require("../../.assets/darkBlueLogoText.png");
 
-  const logoUrl = darkThemeSetting ? DARK_LOGO : LIGHT_LOGO;
+  const logoUrl = themeName === "dark" ? DARK_LOGO : LIGHT_LOGO;
 
   const statisticsButton = (currentPage: string) => {
     if (currentPage !== "StatisticsPage") {

--- a/sudokuru/app/Components/Profile/PreferencesToggles.tsx
+++ b/sudokuru/app/Components/Profile/PreferencesToggles.tsx
@@ -2,11 +2,10 @@ import React from "react";
 import { View } from "react-native";
 import { Switch, Text } from "react-native-paper";
 import { PreferencesContext } from "../../Contexts/PreferencesContext";
+import { useTheme } from "../../Contexts/ThemeContext";
 
 const PreferencesToggles = () => {
   const {
-    toggleTheme,
-    darkThemeSetting,
     toggleHighlightIdenticalValues,
     highlightIdenticalValuesSetting,
     highlightBoxSetting,
@@ -16,19 +15,13 @@ const PreferencesToggles = () => {
     toggleHighlightRow,
     highlightRowSetting,
   } = React.useContext(PreferencesContext);
+  const { theme } = useTheme();
 
   return (
     <View>
-      <Text>Theme</Text>
-      <Switch
-        color={"#025E73"}
-        value={darkThemeSetting}
-        onValueChange={toggleTheme}
-        testID={darkThemeSetting ? "DarkThemeEnabled" : "DarkThemeDisabled"}
-      />
       <Text>Highlight Peers</Text>
       <Switch
-        color={"#025E73"}
+        color={theme.colors.accent}
         value={highlightIdenticalValuesSetting}
         onValueChange={toggleHighlightIdenticalValues}
         testID={
@@ -39,7 +32,7 @@ const PreferencesToggles = () => {
       />
       <Text>Highlight Box</Text>
       <Switch
-        color={"#025E73"}
+        color={theme.colors.accent}
         value={highlightBoxSetting}
         onValueChange={toggleHighlightBox}
         testID={
@@ -48,7 +41,7 @@ const PreferencesToggles = () => {
       />
       <Text>Highlight Row</Text>
       <Switch
-        color={"#025E73"}
+        color={theme.colors.accent}
         value={highlightRowSetting}
         onValueChange={toggleHighlightRow}
         testID={
@@ -57,7 +50,7 @@ const PreferencesToggles = () => {
       />
       <Text>Highlight Column</Text>
       <Switch
-        color={"#025E73"}
+        color={theme.colors.accent}
         value={highlightColumnSetting}
         onValueChange={toggleHighlightColumn}
         testID={

--- a/sudokuru/app/Components/Profile/ProfileToggle.tsx
+++ b/sudokuru/app/Components/Profile/ProfileToggle.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { View } from "react-native";
 import { Switch, Text } from "react-native-paper";
+import { useTheme } from "../../Contexts/ThemeContext";
 
 const ProfileToggle = (props: {
   name: string;
@@ -10,6 +11,7 @@ const ProfileToggle = (props: {
   testIdPrefix: string;
 }) => {
   const { fontSize = 25 } = props;
+  const { theme } = useTheme();
 
   return (
     <View
@@ -19,11 +21,11 @@ const ProfileToggle = (props: {
         justifyContent: "space-between",
       }}
     >
-      <Text style={{ fontSize: fontSize, color: "#025E73" }}>
+      <Text style={{ fontSize: fontSize, color: theme.colors.text }}>
         {props.name}:{" "}
       </Text>
       <Switch
-        color={"#025E73"}
+        color={theme.colors.accent}
         value={props.value}
         onValueChange={props.valueToggle}
         testID={

--- a/sudokuru/app/Components/Profile/StrategyOrder.tsx
+++ b/sudokuru/app/Components/Profile/StrategyOrder.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { View, TouchableOpacity } from "react-native";
 import { IconButton, Text } from "react-native-paper";
+import { useTheme } from "../../Contexts/ThemeContext";
 import { SudokuStrategy } from "sudokuru";
 import { formatOneLessonName } from "../../Functions/learnedLessons";
 import {
@@ -12,6 +13,7 @@ import {
  * This is a component for the user to select what order hints for strategies should be given in
  */
 const StrategyOrder = () => {
+  const { theme } = useTheme();
   const { updateStrategyHintOrder, strategyHintOrderSetting } =
     React.useContext(PreferencesContext);
 
@@ -35,9 +37,9 @@ const StrategyOrder = () => {
     selected: boolean,
     bullet = "•",
   ) => {
-    let borderColor = "grey";
+    let borderColor = theme.colors.border;
     if (selected) {
-      borderColor = "#D9A05B";
+      borderColor = theme.colors.accent;
     }
 
     const updateSelectedElement = (order: number) => {
@@ -62,10 +64,12 @@ const StrategyOrder = () => {
         key={key}
         onPress={() => setSelectedElement(updateSelectedElement(order))}
       >
-        <Text style={{ fontSize: 14, color: "#025E73", minWidth: 20 }}>
+        <Text style={{ fontSize: 14, color: theme.colors.text, minWidth: 20 }}>
           {bullet}
         </Text>
-        <Text style={{ fontSize: 14, paddingLeft: 5, color: "#025E73" }}>
+        <Text
+          style={{ fontSize: 14, paddingLeft: 5, color: theme.colors.text }}
+        >
           {point}
         </Text>
       </TouchableOpacity>
@@ -141,9 +145,9 @@ const StrategyOrder = () => {
   const incrementButtonColor = (index: number, button: "up" | "down") => {
     const disabled = isIncrementButtonDisabled(index, button);
     if (disabled) {
-      return "grey";
+      return theme.colors.textMuted;
     } else {
-      return "#025E73";
+      return theme.colors.text;
     }
   };
 
@@ -167,14 +171,16 @@ const StrategyOrder = () => {
 
   return (
     <>
-      <Text style={{ color: "#025E73", fontSize: 25, alignSelf: "center" }}>
+      <Text
+        style={{ color: theme.colors.text, fontSize: 25, alignSelf: "center" }}
+      >
         Strategy Hint Order
       </Text>
       <View style={{ flexDirection: "row", justifyContent: "space-evenly" }}>
         <IconButton
           icon="arrow-up"
           iconColor={incrementButtonColor(selectedElement, "up")}
-          theme={{ colors: { onSurfaceDisabled: "grey" } }}
+          theme={{ colors: { onSurfaceDisabled: theme.colors.textMuted } }}
           testID={"HintStrategyMenuUp"}
           size={20}
           style={{
@@ -187,24 +193,24 @@ const StrategyOrder = () => {
         <View style={{ flexDirection: "column", alignItems: "center" }}>
           <IconButton
             icon="refresh"
-            iconColor="#025E73"
+            iconColor={theme.colors.text}
             testID={"HintStrategyMenuReset"}
             size={20}
             style={{
               borderWidth: 2,
-              borderColor: "#025E73",
+              borderColor: theme.colors.text,
             }}
             // need a deep copy of SUDOKU_STRATEGY_ARRAY otherwise it becomes mutated
             onPress={() => {
               updateStrategyHintOrder(returnSudokuStrategyArray());
             }}
           />
-          <Text style={{ color: "#025E73" }}>RESET</Text>
+          <Text style={{ color: theme.colors.text }}>RESET</Text>
         </View>
         <IconButton
           icon="arrow-down"
           iconColor={incrementButtonColor(selectedElement, "down")}
-          theme={{ colors: { onSurfaceDisabled: "grey" } }}
+          theme={{ colors: { onSurfaceDisabled: theme.colors.textMuted } }}
           testID={"HintStrategyMenuDown"}
           size={20}
           style={{

--- a/sudokuru/app/Components/ReleaseNotes/ReleaseNote.tsx
+++ b/sudokuru/app/Components/ReleaseNotes/ReleaseNote.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { View } from "react-native";
 import { Divider, Text } from "react-native-paper";
+import { useTheme } from "../../Contexts/ThemeContext";
 
 export interface ReleaseNoteInterface {
   version: string;
@@ -74,10 +75,11 @@ export const ReleaseNote = (
   const targetPlatformsString = BulletedListComponent(props.targets);
   const contributorsString = BulletedListComponent(props.contributors);
 
+  const { theme } = useTheme();
   return (
     <View
       style={{
-        backgroundColor: "#012D39",
+        backgroundColor: theme.colors.surfaceAlt,
         borderRadius: 20,
         padding: 10,
         marginBottom: 10,

--- a/sudokuru/app/Components/Statistics/Statistic.tsx
+++ b/sudokuru/app/Components/Statistics/Statistic.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Text } from "react-native-paper";
 import { View, useWindowDimensions } from "react-native";
+import { useTheme } from "../../Contexts/ThemeContext";
 
 interface StatisticProps {
   statisticName: string;
@@ -11,16 +12,22 @@ interface StatisticProps {
 const Statistic = (props: StatisticProps) => {
   const size = useWindowDimensions();
   const reSize = Math.min(size.width, size.height);
+  const { theme } = useTheme();
   return (
     <View style={{ flexDirection: "row" }}>
-      <Text style={{ fontSize: reSize ? reSize / 20 : 20, color: "#025E73" }}>
+      <Text
+        style={{
+          fontSize: reSize ? reSize / 20 : 20,
+          color: theme.colors.text,
+        }}
+      >
         {props.statisticName}
       </Text>
       <Text
         style={{
           fontSize: reSize ? reSize / 20 : 20,
           fontWeight: "bold",
-          color: "#D9A05B",
+          color: theme.colors.accent,
         }}
         testID={props.testID}
       >

--- a/sudokuru/app/Components/Statistics/TotalStatistics.tsx
+++ b/sudokuru/app/Components/Statistics/TotalStatistics.tsx
@@ -1,5 +1,6 @@
-import { Text, useTheme } from "react-native-paper";
+import { Text } from "react-native-paper";
 import { useWindowDimensions, View } from "react-native";
+import { useTheme } from "../../Contexts/ThemeContext";
 import Statistic from "./Statistic";
 import { formatTime } from "../SudokuBoard/Core/Functions/BoardFunctions";
 import { SudokuStrategy } from "sudokuru";
@@ -24,7 +25,7 @@ const TotalStatistics = (props: TotalStatisticsProps) => {
   const size = useWindowDimensions();
   const reSize = Math.min(size.width, size.height);
 
-  const theme = useTheme();
+  const { theme } = useTheme();
 
   return (
     <View
@@ -37,14 +38,20 @@ const TotalStatistics = (props: TotalStatisticsProps) => {
       <Text
         style={{
           fontSize: reSize ? reSize / 20 : 20,
-          color: theme.colors.primary,
+          color: theme.colors.accent,
           fontWeight: "bold",
           marginBottom: 10,
         }}
       >
         Total Game Statistics
       </Text>
-      <View style={{ backgroundColor: "#fff", borderRadius: 10, padding: 20 }}>
+      <View
+        style={{
+          backgroundColor: theme.colors.surface,
+          borderRadius: 10,
+          padding: 20,
+        }}
+      >
         <Statistic
           statisticName="Total Score: "
           statisticValue={props.totalScore}

--- a/sudokuru/app/Components/SudokuBoard/Core/Components/EndGameModal.tsx
+++ b/sudokuru/app/Components/SudokuBoard/Core/Components/EndGameModal.tsx
@@ -1,5 +1,6 @@
 import { Button, Text } from "react-native-paper";
 import { useWindowDimensions, ScrollView, View } from "react-native";
+import { useTheme } from "../../../../Contexts/ThemeContext";
 import { useNavigation } from "@react-navigation/native";
 import Statistic from "../../../Statistics/Statistic";
 import { formatTime } from "../Functions/BoardFunctions";
@@ -24,6 +25,7 @@ const EndGameModal = (props: EndGameModalProps) => {
   const reSize = Math.min(size.width, size.height);
 
   const navigation: any = useNavigation();
+  const { theme } = useTheme();
 
   return (
     <ScrollView
@@ -36,14 +38,20 @@ const EndGameModal = (props: EndGameModalProps) => {
       <Text
         style={{
           fontSize: reSize ? reSize / 20 : 20,
-          color: "#D9A05B",
+          color: theme.colors.accent,
           fontWeight: "bold",
           marginBottom: 10,
         }}
       >
         Game Results
       </Text>
-      <View style={{ backgroundColor: "#fff", borderRadius: 10, padding: 20 }}>
+      <View
+        style={{
+          backgroundColor: theme.colors.surface,
+          borderRadius: 10,
+          padding: 20,
+        }}
+      >
         <Statistic
           statisticName="Score: "
           statisticValue={props.score}

--- a/sudokuru/app/Components/SudokuBoard/Core/Components/NumberControl.tsx
+++ b/sudokuru/app/Components/SudokuBoard/Core/Components/NumberControl.tsx
@@ -1,4 +1,4 @@
-import { useTheme } from "react-native-paper";
+import { useTheme } from "../../../../Contexts/ThemeContext";
 import { Pressable, Text, View } from "react-native";
 import { range } from "../../SudokuBoardFunctions";
 import React from "react";
@@ -29,7 +29,7 @@ const NumberControl = (props: NumberControlProps) => {
     sudokuBoard,
   } = props;
   const cellSize = useCellSize();
-  const theme = useTheme();
+  const { theme } = useTheme();
 
   const { darkThemeSetting, progressIndicatorSetting } =
     React.useContext(PreferencesContext);
@@ -61,8 +61,8 @@ const NumberControl = (props: NumberControlProps) => {
             >
               <LinearGradient
                 colors={[
-                  darkThemeSetting ? "white" : "grey",
-                  theme.colors.primaryContainer,
+                  darkThemeSetting ? theme.colors.text : theme.colors.textMuted,
+                  theme.colors.accent,
                 ]}
                 locations={[
                   1 - getRemainingCellCountOfValue(sudokuBoard, number) / 9,
@@ -85,7 +85,7 @@ const NumberControl = (props: NumberControlProps) => {
                     fontSize: cellSize
                       ? cellSize * (3 / 4) + 1
                       : fallbackHeight * (3 / 4) + 1,
-                    color: theme.colors.onPrimaryContainer,
+                    color: theme.colors.text,
                   }}
                   selectable={false}
                 >
@@ -106,7 +106,7 @@ const NumberControl = (props: NumberControlProps) => {
                   : fallbackHeight * (50 / 60),
                 height: cellSize || fallbackHeight,
                 alignItems: "center",
-                backgroundColor: theme.colors.primaryContainer,
+                backgroundColor: theme.colors.accent,
                 borderRadius: cellSize
                   ? cellSize * (10 / 60)
                   : fallbackHeight * (10 / 60),

--- a/sudokuru/app/Components/SudokuBoard/Core/Components/NumberControl.tsx
+++ b/sudokuru/app/Components/SudokuBoard/Core/Components/NumberControl.tsx
@@ -29,10 +29,9 @@ const NumberControl = (props: NumberControlProps) => {
     sudokuBoard,
   } = props;
   const cellSize = useCellSize();
-  const { theme } = useTheme();
+  const { themeName, theme } = useTheme();
 
-  const { darkThemeSetting, progressIndicatorSetting } =
-    React.useContext(PreferencesContext);
+  const { progressIndicatorSetting } = React.useContext(PreferencesContext);
 
   return (
     <View
@@ -61,7 +60,9 @@ const NumberControl = (props: NumberControlProps) => {
             >
               <LinearGradient
                 colors={[
-                  darkThemeSetting ? theme.colors.text : theme.colors.textMuted,
+                  themeName === "dark"
+                    ? theme.colors.text
+                    : theme.colors.textMuted,
                   theme.colors.accent,
                 ]}
                 locations={[
@@ -119,7 +120,7 @@ const NumberControl = (props: NumberControlProps) => {
                   fontSize: cellSize
                     ? cellSize * (3 / 4) + 1
                     : fallbackHeight * (3 / 4) + 1,
-                  color: theme.colors.onPrimaryContainer,
+                  color: theme.colors.text,
                 }}
                 selectable={false}
               >

--- a/sudokuru/app/Components/SudokuBoard/Core/Functions/RenderCellFunctions.ts
+++ b/sudokuru/app/Components/SudokuBoard/Core/Functions/RenderCellFunctions.ts
@@ -14,6 +14,9 @@ import {
   PEER_SELECTED_COLOR,
   HINT_SELECTED_COLOR,
   HINT_NOT_HIGHLIGHTED_COLOR,
+  NOTE_TEXT_COLOR,
+  REMOVE_NOTE_TEXT_COLOR,
+  NOT_HIGHLIGHTED_COLOR,
 } from "../../../../Styling/HighlightColors";
 import { HintObjectProps } from "../../SudokuBoard";
 import {
@@ -41,7 +44,7 @@ export const getCellNotesColor = (
   r: number,
   c: number,
 ) => {
-  const notesToReturn = Array(9).fill("black");
+  const notesToReturn = Array(9).fill(NOTE_TEXT_COLOR);
   // change note color to red for note removals as part of hint
   if (sudokuHint && sudokuHint.stage === 4) {
     const hintNotes = JSON.parse(JSON.stringify(sudokuHint.hint.removals));
@@ -49,7 +52,7 @@ export const getCellNotesColor = (
       if (notes[0] === r && notes[1] === c) {
         notes.splice(0, 2);
         for (const note of notes) {
-          notesToReturn[note - 1] = "red";
+          notesToReturn[note - 1] = REMOVE_NOTE_TEXT_COLOR;
         }
       }
     }
@@ -104,7 +107,7 @@ export const useCellBackgroundColor = (
   } else if (peer) {
     cellBackgroundColor = PEER_SELECTED_COLOR;
   } else {
-    cellBackgroundColor = "white";
+    cellBackgroundColor = NOT_HIGHLIGHTED_COLOR;
   }
 
   if (sudokuHint) {

--- a/sudokuru/app/Components/SudokuBoard/SudokuBoard.tsx
+++ b/sudokuru/app/Components/SudokuBoard/SudokuBoard.tsx
@@ -11,6 +11,7 @@ import {
   wrapDigit,
 } from "./SudokuBoardFunctions";
 import { ActivityIndicator } from "react-native-paper";
+import { useTheme } from "../../Contexts/ThemeContext";
 import NumberControl from "./Core/Components/NumberControl";
 import ActionRow from "./Core/Components/ActionRow";
 import { generateGame } from "./Core/Functions/GenerateGameFunctions";
@@ -67,6 +68,8 @@ const SudokuBoard = (props: SudokuBoardProps) => {
   const [gameOver, setGameOver] = useState(false);
   const navigation = useNavigation();
 
+  const { theme } = useTheme();
+
   const [sudokuHint, setSudokuHint] = useState<HintObjectProps>();
 
   const {
@@ -95,7 +98,7 @@ const SudokuBoard = (props: SudokuBoardProps) => {
 
   // if we are loading then we return the loading icon
   if (sudokuBoard == null) {
-    return <ActivityIndicator animating={true} color="red" />;
+    return <ActivityIndicator animating={true} color={theme.colors.danger} />;
   }
 
   // Render EndGame screen when game has ended

--- a/sudokuru/app/Contexts/InitializeContext.ts
+++ b/sudokuru/app/Contexts/InitializeContext.ts
@@ -1,14 +1,9 @@
 import React from "react";
-import {
-  CombinedDarkTheme,
-  CombinedDefaultTheme,
-} from "../Styling/ThemeColors";
 import { getProfile, setProfileValue } from "../Api/Profile";
 import { SUDOKU_STRATEGY_ARRAY, SudokuStrategy } from "sudokuru";
 import { Profile } from "../Api/Puzzle.Types";
 
 const InitializeContext = () => {
-  const [darkThemeSetting, setDarkThemeSetting] = React.useState(true);
   const [currentPage, setCurrentPage] = React.useState("Home");
   const [learnedLessons, setLearnedLessons] = React.useState(["NONE"]);
   const [highlightIdenticalValuesSetting, setHighlightIdenticalValuesSetting] =
@@ -35,7 +30,6 @@ const InitializeContext = () => {
   // set initial values of theme
   React.useEffect(() => {
     getProfile().then((data: Profile) => {
-      setDarkThemeSetting(data.theme);
       setHighlightIdenticalValuesSetting(data.highlightIdenticalValues);
       setHighlightBoxSetting(data.highlightBox);
       setHighlightRowSetting(data.highlightRow);
@@ -47,13 +41,6 @@ const InitializeContext = () => {
       setSimplifyNotesSetting(data.simplifyNotes);
     });
   }, []);
-
-  const theme = darkThemeSetting ? CombinedDarkTheme : CombinedDefaultTheme;
-
-  const toggleTheme = React.useCallback(() => {
-    setProfileValue("theme");
-    return setDarkThemeSetting(!darkThemeSetting);
-  }, [darkThemeSetting]);
 
   const updateCurrentPage = React.useCallback(
     (props: React.SetStateAction<string>) => {
@@ -122,8 +109,6 @@ const InitializeContext = () => {
 
   const preferences = React.useMemo(
     () => ({
-      toggleTheme,
-      darkThemeSetting,
       updateCurrentPage,
       currentPage,
       updateLearnedLessons,
@@ -148,8 +133,6 @@ const InitializeContext = () => {
       strategyHintOrderSetting,
     }),
     [
-      toggleTheme,
-      darkThemeSetting,
       updateCurrentPage,
       currentPage,
       updateLearnedLessons,
@@ -176,7 +159,6 @@ const InitializeContext = () => {
   );
 
   return {
-    theme,
     preferences,
   };
 };

--- a/sudokuru/app/Contexts/PreferencesContext.ts
+++ b/sudokuru/app/Contexts/PreferencesContext.ts
@@ -7,8 +7,6 @@ export const returnSudokuStrategyArray = () => {
 };
 
 export const PreferencesContext = React.createContext({
-  toggleTheme: () => {},
-  darkThemeSetting: false,
   updateCurrentPage: (props: any) => {},
   currentPage: "Home",
   updateLearnedLessons: (props: any) => {},

--- a/sudokuru/app/Contexts/ThemeContext.tsx
+++ b/sudokuru/app/Contexts/ThemeContext.tsx
@@ -1,0 +1,81 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+import {
+  NavigationContainer,
+  DefaultTheme as NavigationDefaultTheme,
+} from "@react-navigation/native";
+import { MD3LightTheme, Provider as PaperProvider } from "react-native-paper";
+import { Theme, themes, ThemeName } from "../Styling/theme";
+import { getStoredTheme, setStoredTheme } from "../Api/Theme";
+
+interface ThemeContextValue {
+  themeName: ThemeName;
+  theme: Theme;
+  setTheme: (name: ThemeName) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  themeName: "classic",
+  theme: themes.classic,
+  setTheme: () => {},
+});
+
+export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
+  const [themeName, setThemeName] = useState<ThemeName>("classic");
+
+  useEffect(() => {
+    getStoredTheme().then((stored) => {
+      if (stored && themes[stored as ThemeName]) {
+        setThemeName(stored as ThemeName);
+      }
+    });
+  }, []);
+
+  const setTheme = (name: ThemeName) => {
+    setThemeName(name);
+    setStoredTheme(name);
+  };
+
+  const theme = themes[themeName];
+
+  useEffect(() => {
+    if (typeof document !== "undefined") {
+      document.documentElement.dataset.theme = themeName;
+    }
+  }, [themeName]);
+
+  const paperTheme = {
+    ...MD3LightTheme,
+    colors: {
+      ...MD3LightTheme.colors,
+      primary: theme.colors.accent,
+      background: theme.colors.bg,
+      surface: theme.colors.surface,
+      onPrimary: theme.colors.text,
+      onSurface: theme.colors.text,
+    },
+  } as any;
+
+  const navigationTheme = {
+    ...NavigationDefaultTheme,
+    colors: {
+      ...NavigationDefaultTheme.colors,
+      background: theme.colors.bg,
+      primary: theme.colors.accent,
+      text: theme.colors.text,
+      card: theme.colors.surface,
+      border: theme.colors.border,
+    },
+  };
+
+  return (
+    <ThemeContext.Provider value={{ themeName, theme, setTheme }}>
+      <PaperProvider theme={paperTheme}>
+        <NavigationContainer theme={navigationTheme}>
+          {children}
+        </NavigationContainer>
+      </PaperProvider>
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => useContext(ThemeContext);

--- a/sudokuru/app/Navigation/DrawerNavigator.tsx
+++ b/sudokuru/app/Navigation/DrawerNavigator.tsx
@@ -20,7 +20,7 @@ import AboutUsPage from "../Pages/AboutUsPage";
 const Drawer = createDrawerNavigator();
 
 const DrawerNavigator = () => {
-  const theme = useTheme();
+  const { theme } = useTheme();
 
   return (
     <SafeAreaProvider>

--- a/sudokuru/app/Navigation/DrawerNavigator.tsx
+++ b/sudokuru/app/Navigation/DrawerNavigator.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { createDrawerNavigator } from "@react-navigation/drawer";
 import Header from "../Components/Header";
 import NavigationSideBar from "../Components/NavigationSideBar";
-import { useTheme } from "react-native-paper";
+import { useTheme } from "../Contexts/ThemeContext";
 import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
 import StatisticsPage from "../Pages/StatisticsPage";
 import ProfilePage from "../Pages/ProfilePage";
@@ -25,7 +25,8 @@ const DrawerNavigator = () => {
   return (
     <SafeAreaProvider>
       <SafeAreaView
-        style={{ flex: 1, backgroundColor: theme.colors.background }}
+        testID="AppRoot"
+        style={{ flex: 1, backgroundColor: theme.colors.bg }}
       >
         <Drawer.Navigator
           drawerContent={({ navigation }) => {
@@ -34,7 +35,7 @@ const DrawerNavigator = () => {
           screenOptions={{
             drawerStyle: {
               width: 230,
-              backgroundColor: theme.colors.background,
+              backgroundColor: theme.colors.bg,
               overflow: "hidden", //white space was being caused during some resizes
             },
             headerShown: true,

--- a/sudokuru/app/Pages/ContactPage.tsx
+++ b/sudokuru/app/Pages/ContactPage.tsx
@@ -6,8 +6,8 @@ import {
   SegmentedButtons,
   Text,
   TextInput,
-  useTheme,
 } from "react-native-paper";
+import { useTheme } from "../Contexts/ThemeContext";
 import {
   CARD_IMAGE_HEIGHT,
   CARD_PADDING,
@@ -17,7 +17,7 @@ import { useNavigation } from "@react-navigation/native";
 import { PreferencesContext } from "../Contexts/PreferencesContext";
 
 const ContactPage = () => {
-  const theme = useTheme();
+  const { theme } = useTheme();
   const navigation: any = useNavigation();
   const { updateCurrentPage } = React.useContext(PreferencesContext);
   const size = useWindowDimensions();
@@ -162,8 +162,11 @@ const ContactPage = () => {
               label={contactPage.label}
               value={contactPage.text}
               placeholder={contactPage.placeholder}
-              style={{ backgroundColor: "white", height: CARD_IMAGE_HEIGHT }}
-              textColor="black"
+              style={{
+                backgroundColor: theme.colors.surface,
+                height: CARD_IMAGE_HEIGHT,
+              }}
+              textColor={theme.colors.text}
               multiline={true}
               onChangeText={(text) => {
                 let disableButton: boolean = true;

--- a/sudokuru/app/Pages/ContactPage.tsx
+++ b/sudokuru/app/Pages/ContactPage.tsx
@@ -223,7 +223,7 @@ const ContactPage = () => {
         >
           <View
             style={{
-              backgroundColor: theme.colors.onSurface,
+              backgroundColor: theme.colors.surface,
               alignSelf: "center",
               width: CARD_WIDTH * 1.08,
               height: CARD_IMAGE_HEIGHT * 0.9,
@@ -235,15 +235,17 @@ const ContactPage = () => {
           >
             <Text
               variant="headlineSmall"
-              style={{ alignSelf: "center" }}
-              theme={{ colors: { onSurface: theme.colors.onPrimary } }}
+              style={{ alignSelf: "center", color: theme.colors.text }}
             >
               Thank You!
             </Text>
             <Text
               variant="bodyLarge"
-              style={{ alignSelf: "center", textAlign: "center" }}
-              theme={{ colors: { onSurface: theme.colors.onPrimary } }}
+              style={{
+                alignSelf: "center",
+                textAlign: "center",
+                color: theme.colors.text,
+              }}
             >
               Your feedback has been submitted.{"\n"}
               We appreciate the time you took to help us improve our app.{"\n"}
@@ -278,7 +280,7 @@ const ContactPage = () => {
         >
           <View
             style={{
-              backgroundColor: theme.colors.onSurface,
+              backgroundColor: theme.colors.surface,
               alignSelf: "center",
               width: CARD_WIDTH * 1.08,
               height: CARD_IMAGE_HEIGHT * 0.7,
@@ -290,15 +292,13 @@ const ContactPage = () => {
           >
             <Text
               variant="headlineSmall"
-              style={{ alignSelf: "center" }}
-              theme={{ colors: { onSurface: theme.colors.onPrimary } }}
+              style={{ alignSelf: "center", color: theme.colors.text }}
             >
               Error
             </Text>
             <Text
               variant="bodyLarge"
-              style={{ alignSelf: "center" }}
-              theme={{ colors: { onSurface: theme.colors.onPrimary } }}
+              style={{ alignSelf: "center", color: theme.colors.text }}
             >
               There was an error submitting your feedback.{"\n"}
               Please try again later.

--- a/sudokuru/app/Pages/ProfilePage.tsx
+++ b/sudokuru/app/Pages/ProfilePage.tsx
@@ -5,21 +5,21 @@ import {
   useWindowDimensions,
   ScaledSize,
 } from "react-native";
-import { Text, useTheme } from "react-native-paper";
+import { Text, Button } from "react-native-paper";
+import { useTheme as useAppTheme } from "../Contexts/ThemeContext";
+import { ThemeName } from "../Styling/theme";
 import { PreferencesContext } from "../Contexts/PreferencesContext";
 import { formatLessonNameArray } from "../Functions/learnedLessons";
 import ProfileToggle from "../Components/Profile/ProfileToggle";
 import StrategyOrder from "../Components/Profile/StrategyOrder";
 
 const ProfilePage = () => {
-  const theme = useTheme();
+  const { theme, themeName, setTheme } = useAppTheme();
 
   const size = useWindowDimensions();
 
   const {
     learnedLessons,
-    toggleTheme,
-    darkThemeSetting,
     toggleHighlightIdenticalValues,
     highlightIdenticalValuesSetting,
     highlightBoxSetting,
@@ -81,7 +81,7 @@ const ProfilePage = () => {
       <Text
         style={{
           fontSize: 40,
-          color: theme.colors.primary,
+          color: theme.colors.accent,
           fontWeight: "bold",
           marginBottom: 10,
         }}
@@ -91,7 +91,7 @@ const ProfilePage = () => {
       <View style={{ flexDirection: profileFlexDirection(size) }}>
         <View
           style={{
-            backgroundColor: "#fff",
+            backgroundColor: theme.colors.surface,
             borderRadius: 10,
             padding: 20,
             margin: 20,
@@ -99,7 +99,7 @@ const ProfilePage = () => {
           }}
         >
           <View style={{ marginBottom: 10 }}>
-            <Text style={{ fontSize: 25, color: "#025E73" }}>
+            <Text style={{ fontSize: 25, color: theme.colors.text }}>
               Strategies Learned:
             </Text>
             <Text
@@ -107,18 +107,37 @@ const ProfilePage = () => {
               style={{
                 fontSize: 20,
                 fontWeight: "bold",
-                color: "#D9A05B",
+                color: theme.colors.accent,
               }}
             >
               {formatLessonNameArray(learnedLessons)}
             </Text>
           </View>
-          <ProfileToggle
-            name="Theme"
-            value={darkThemeSetting}
-            valueToggle={toggleTheme}
-            testIdPrefix="DarkTheme"
-          ></ProfileToggle>
+          <View
+            style={{
+              marginBottom: 10,
+              flexDirection: "row",
+              justifyContent: "space-between",
+            }}
+          >
+            <Text style={{ fontSize: 25, color: theme.colors.text }}>
+              Theme: {themeName}
+            </Text>
+            <Button
+              mode="contained"
+              buttonColor={theme.colors.accent}
+              textColor={theme.colors.text}
+              onPress={() => {
+                const names: ThemeName[] = ["classic", "light", "dark"];
+                const next =
+                  names[(names.indexOf(themeName) + 1) % names.length];
+                setTheme(next);
+              }}
+              testID="ThemeToggle"
+            >
+              Change
+            </Button>
+          </View>
           <ProfileToggle
             name="Highlight"
             value={highlightMode()}
@@ -184,7 +203,7 @@ const ProfilePage = () => {
         </View>
         <View
           style={{
-            backgroundColor: "#fff",
+            backgroundColor: theme.colors.surface,
             borderRadius: 10,
             padding: 20,
             margin: 20,

--- a/sudokuru/app/Pages/StatisticsPage.tsx
+++ b/sudokuru/app/Pages/StatisticsPage.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Modal, ScrollView, View } from "react-native";
-import { Button, useTheme, ActivityIndicator, Text } from "react-native-paper";
+import { Button, ActivityIndicator, Text } from "react-native-paper";
+import { useTheme } from "../Contexts/ThemeContext";
 import { PreferencesContext } from "../Contexts/PreferencesContext";
 import { useFocusEffect } from "@react-navigation/core";
 import { deleteStatistics, getStatistics } from "../Api/Statistics";
@@ -9,7 +10,7 @@ import { Statistics } from "../Api/Puzzle.Types";
 import { CARD_IMAGE_HEIGHT, CARD_WIDTH } from "../Components/Home/Cards";
 
 const StatisticsPage = () => {
-  const theme = useTheme();
+  const { theme } = useTheme();
 
   const { updateLearnedLessons } = React.useContext(PreferencesContext);
 
@@ -136,11 +137,11 @@ const StatisticsPage = () => {
               >
                 <Button
                   mode="contained"
-                  buttonColor="grey"
+                  buttonColor={theme.colors.border}
                   onPress={hideWarningButton}
                   labelStyle={{
                     fontSize: 20,
-                    color: "white",
+                    color: theme.colors.surface,
                     fontWeight: "bold",
                   }}
                   style={{
@@ -152,7 +153,7 @@ const StatisticsPage = () => {
                 </Button>
                 <Button
                   mode="contained"
-                  buttonColor="red"
+                  buttonColor={theme.colors.danger}
                   onPress={() => {
                     deleteUserStatistics().then(() => {
                       hideWarningButton();
@@ -160,7 +161,7 @@ const StatisticsPage = () => {
                   }}
                   labelStyle={{
                     fontSize: 20,
-                    color: "white",
+                    color: theme.colors.surface,
                     fontWeight: "bold",
                   }}
                   testID="confirmDeleteButton"

--- a/sudokuru/app/Pages/StatisticsPage.tsx
+++ b/sudokuru/app/Pages/StatisticsPage.tsx
@@ -101,7 +101,7 @@ const StatisticsPage = () => {
           >
             <View
               style={{
-                backgroundColor: theme.colors.onSurface,
+                backgroundColor: theme.colors.surface,
                 alignSelf: "center",
                 width: CARD_WIDTH * 1.2,
                 height: CARD_IMAGE_HEIGHT * 1,
@@ -113,15 +113,21 @@ const StatisticsPage = () => {
             >
               <Text
                 variant="headlineMedium"
-                style={{ alignSelf: "center", margin: CARD_IMAGE_HEIGHT / 50 }}
-                theme={{ colors: { onSurface: theme.colors.onPrimary } }}
+                style={{
+                  alignSelf: "center",
+                  margin: CARD_IMAGE_HEIGHT / 50,
+                  color: theme.colors.text,
+                }}
               >
                 Are you sure?
               </Text>
               <Text
                 variant="bodyLarge"
-                style={{ alignSelf: "center", textAlign: "center" }}
-                theme={{ colors: { onSurface: theme.colors.onPrimary } }}
+                style={{
+                  alignSelf: "center",
+                  textAlign: "center",
+                  color: theme.colors.text,
+                }}
               >
                 Do you really want to delete your progress?{"\n"}
                 This includes lesson completions.{"\n"}

--- a/sudokuru/app/Styling/contrast.ts
+++ b/sudokuru/app/Styling/contrast.ts
@@ -1,0 +1,19 @@
+// Simple WCAG contrast ratio helper
+export const luminance = (hex: string) => {
+  const rgb = hex
+    .replace("#", "")
+    .match(/.{2}/g)!
+    .map((x) => parseInt(x, 16) / 255)
+    .map((c) =>
+      c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4),
+    );
+  return 0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2];
+};
+
+export const contrastRatio = (hex1: string, hex2: string) => {
+  const l1 = luminance(hex1);
+  const l2 = luminance(hex2);
+  const brightest = Math.max(l1, l2);
+  const darkest = Math.min(l1, l2);
+  return (brightest + 0.05) / (darkest + 0.05);
+};

--- a/sudokuru/app/Styling/theme.ts
+++ b/sudokuru/app/Styling/theme.ts
@@ -1,0 +1,95 @@
+export type Theme = {
+  colors: {
+    bg: string;
+    surface: string;
+    surfaceAlt: string;
+    text: string;
+    textMuted: string;
+    border: string;
+    accent: string;
+    primary: string;
+    accentMuted: string;
+    link: string;
+    danger: string;
+    warn: string;
+    success: string;
+    overlay: string;
+    focus: string;
+    selection: string;
+    shadow: string;
+  };
+};
+
+export type ThemeName = keyof typeof themes;
+
+const classic: Theme = {
+  colors: {
+    bg: "#025E73",
+    surface: "#FFFFFF",
+    surfaceAlt: "#012D39",
+    text: "#025E73",
+    textMuted: "#D9A05B",
+    border: "#025E73",
+    accent: "#D9A05B",
+    primary: "#D9A05B",
+    accentMuted: "#D9A05B99",
+    link: "#D9A05B",
+    danger: "#FF0000",
+    warn: "#FFA500",
+    success: "#4CBB17",
+    overlay: "#00000080",
+    focus: "#F2CA7E",
+    selection: "#9CC4EC",
+    shadow: "#00000033",
+  },
+};
+
+const light: Theme = {
+  colors: {
+    bg: "#FFFFFF",
+    surface: "#FFFFFF",
+    surfaceAlt: "#F5F5F5",
+    text: "#111111",
+    textMuted: "#555555",
+    border: "#CCCCCC",
+    accent: "#025E73",
+    primary: "#025E73",
+    accentMuted: "#025E7399",
+    link: "#025E73",
+    danger: "#B00020",
+    warn: "#F9A825",
+    success: "#388E3C",
+    overlay: "#00000080",
+    focus: "#025E73",
+    selection: "#BBDEFB",
+    shadow: "#00000033",
+  },
+};
+
+const dark: Theme = {
+  colors: {
+    bg: "#121212",
+    surface: "#1E1E1E",
+    surfaceAlt: "#2C2C2C",
+    text: "#E0E0E0",
+    textMuted: "#AAAAAA",
+    border: "#333333",
+    accent: "#D9A05B",
+    primary: "#D9A05B",
+    accentMuted: "#D9A05B99",
+    link: "#8AB4F8",
+    danger: "#CF6679",
+    warn: "#FBC02D",
+    success: "#81C784",
+    overlay: "#000000B3",
+    focus: "#BB86FC",
+    selection: "#333333",
+    shadow: "#00000066",
+  },
+};
+
+export const themes = {
+  classic,
+  light,
+  dark,
+};


### PR DESCRIPTION
## Summary
- introduce typed theme tokens and three themes (classic, light, dark)
- add ThemeProvider with persistence and update Profile page toggle
- document theme system, color lint, and add Playwright tests

## Testing
- `npm run lint`
- `npm run lint:colors`
- `CI=true WORKERS=1 CODE_COVERAGE=0 BASE_URL=http://localhost:8081 npm run playwright:test -- e2e/web/specs/theme.spec.ts` *(fails: missing server / env setup)*

------
https://chatgpt.com/codex/tasks/task_e_689e8a35aab88332b3d6b3b4cf7739a0