### PR TITLE
Fixing sudoku board hotkeys so they work even when sudoku board is not selected

### DIFF
--- a/e2e/web/specs/classicboard/board-buttons-and-shortcuts.spec.ts
+++ b/e2e/web/specs/classicboard/board-buttons-and-shortcuts.spec.ts
@@ -20,7 +20,6 @@ test.describe("hint", () => {
     const capital = key === "H" ? "capital " : "";
     test("hint button: " + capital + key, async ({ resumeClassicGame }) => {
       const sudokuBoard = new SudokuBoardComponent(resumeClassicGame);
-      await sudokuBoard.cell[0][0].click();
       for (let i = 0; i < 6; i++) {
         await sudokuBoard.page.keyboard.press(key);
       }
@@ -35,7 +34,6 @@ test.describe("pause", () => {
     const capital = key === "P" ? "capital " : "";
     test("pause button: " + capital + key, async ({ resumeClassicGame }) => {
       const sudokuBoard = new SudokuBoardComponent(resumeClassicGame);
-      await sudokuBoard.cell[0][0].click();
       if (key === "button") {
         await sudokuBoard.pause.click();
       } else {

--- a/e2e/web/specs/drillboard/board-buttons-and-shortcuts.spec.ts
+++ b/e2e/web/specs/drillboard/board-buttons-and-shortcuts.spec.ts
@@ -22,7 +22,6 @@ test.describe("hint", () => {
     const capital = key === "H" ? "capital " : "";
     test("hint button: " + capital + key, async ({ resumeDrillGame }) => {
       const sudokuBoard = new SudokuBoardComponent(resumeDrillGame);
-      await sudokuBoard.cell[0][0].click();
       for (let i = 0; i < 6; i++) {
         await sudokuBoard.page.keyboard.press(key);
       }
@@ -38,7 +37,6 @@ test.describe("pause", () => {
     const capital = key === "P" ? "capital " : "";
     test("pause button: " + capital + key, async ({ resumeDrillGame }) => {
       const sudokuBoard = new SudokuBoardComponent(resumeDrillGame);
-      await sudokuBoard.cell[0][0].click();
       if (key === "button") {
         await sudokuBoard.pause.click();
       } else {

--- a/sudokuru/Changelog.json
+++ b/sudokuru/Changelog.json
@@ -1,7 +1,17 @@
 [
   {
-    "version": "1.32.0",
+    "version": "1.32.1",
     "date": "#{date}#",
+    "summary": "Sudoku board hotkeys functionality now works even if the board is not selected.",
+    "bug fixes": [
+      "Sudoku board hotkeys now work even if the board is not selected. Previously, hotkeys would only work when the user has selected a cell on the board. Hotkeys would stop working when the user clicked away from the sudoku board."
+    ],
+    "targets": ["web"],
+    "contributors": ["Thomas-Gallant"]
+  },
+  {
+    "version": "1.32.0",
+    "date": "February 19th, 2026",
     "summary": "Added Drills to feature preview and updated hint logic to improve quality of hints given.",
     "preview features": [
       "Added Drill mode functionality back to the site. Drills were removed in version 1.16.0 to reduce complexity of the site while refactoring the codebase. Drills will now show incorrect movies immediately instead of requiring the user to hit a 'check solution' button. The erase button is replaced with a reset button, since reset will be more useful than erase in the context of drills."

--- a/sudokuru/app/Components/SudokuBoard/Core/Functions/useKeyboardHotkeys.ts
+++ b/sudokuru/app/Components/SudokuBoard/Core/Functions/useKeyboardHotkeys.ts
@@ -145,8 +145,6 @@ export const useKeyboardHotkeys = ({
   };
 
   const handleNavigation = (inputValue: string, board: BoardObjectProps) => {
-    let didNavigate = false;
-
     for (let i = 0; i < board.selectedCells.length; i++) {
       let newCol = board.selectedCells[i].c;
       let newRow = board.selectedCells[i].r;
@@ -174,16 +172,13 @@ export const useKeyboardHotkeys = ({
         default:
           return;
       }
-      didNavigate = true;
       board.selectedCells[i] = { r: newRow, c: newCol };
     }
 
-    if (didNavigate) {
-      setSudokuBoard({
-        ...board,
-        selectedCells: board.selectedCells,
-      });
-    }
+    setSudokuBoard({
+      ...board,
+      selectedCells: board.selectedCells,
+    });
   };
 
   // Setup keyboard event listeners for web platform using globalThis.addEventListener

--- a/sudokuru/app/Components/SudokuBoard/Core/Functions/useKeyboardHotkeys.ts
+++ b/sudokuru/app/Components/SudokuBoard/Core/Functions/useKeyboardHotkeys.ts
@@ -53,16 +53,27 @@ export const useKeyboardHotkeys = ({
         board,
         hint,
       })
-    )
+    ) {
+      event.preventDefault();
       return;
+    }
 
     if (board.selectedCells.length === 0) {
       return;
     }
 
-    if (handleDigitEntry(inputValue)) return;
-    if (handleErase(inputValue)) return;
-    handleNavigation(inputValue, board);
+    if (handleDigitEntry(inputValue)) {
+      event.preventDefault();
+      return;
+    }
+    if (handleErase(inputValue)) {
+      event.preventDefault();
+      return;
+    }
+    if (handleNavigation(inputValue, board)) {
+      event.preventDefault();
+      return;
+    }
   };
 
   const handleGeneralHotkeys = ({
@@ -170,7 +181,7 @@ export const useKeyboardHotkeys = ({
           newRow = wrapDigit(newRow + 1);
           break;
         default:
-          return;
+          return false;
       }
       board.selectedCells[i] = { r: newRow, c: newCol };
     }
@@ -179,6 +190,7 @@ export const useKeyboardHotkeys = ({
       ...board,
       selectedCells: board.selectedCells,
     });
+    return true;
   };
 
   // Setup keyboard event listeners for web platform using globalThis.addEventListener

--- a/sudokuru/app/Components/SudokuBoard/Core/Functions/useKeyboardHotkeys.ts
+++ b/sudokuru/app/Components/SudokuBoard/Core/Functions/useKeyboardHotkeys.ts
@@ -33,6 +33,7 @@ export const useKeyboardHotkeys = ({
   const updateHintStageRef = useRef<any>(null);
   const sudokuBoardRef = useRef<any>(null);
   const sudokuHintRef = useRef<any>(null);
+  const gameOverRef = useRef<boolean>(false);
 
   /**
    * When a user presses a key down, do the desired action via globalThis.addEventListener
@@ -41,6 +42,7 @@ export const useKeyboardHotkeys = ({
    * @returns void
    */
   const handleKeyDown = (event: KeyboardEvent) => {
+    if (gameOverRef.current) return;
     if (!sudokuBoardRef.current) return;
 
     const inputValue = event.key;
@@ -211,5 +213,6 @@ export const useKeyboardHotkeys = ({
     updateHintStageRef,
     sudokuBoardRef,
     sudokuHintRef,
+    gameOverRef,
   };
 };

--- a/sudokuru/app/Components/SudokuBoard/Core/Functions/useKeyboardHotkeys.ts
+++ b/sudokuru/app/Components/SudokuBoard/Core/Functions/useKeyboardHotkeys.ts
@@ -35,12 +35,12 @@ export const useKeyboardHotkeys = ({
   const sudokuHintRef = useRef<any>(null);
 
   /**
-   * When a user presses a key down, do the desired action via window.addEventListener
+   * When a user presses a key down, do the desired action via globalThis.addEventListener
    * Uses refs to access current state and function implementations
    * @param event keyboard event
    * @returns void
    */
-  const handleWindowKeyDown = (event: KeyboardEvent) => {
+  const handleKeyDown = (event: KeyboardEvent) => {
     if (!sudokuBoardRef.current) return;
 
     const inputValue = event.key;
@@ -191,8 +191,8 @@ export const useKeyboardHotkeys = ({
   useEffect(() => {
     if (Platform.OS !== "web") return;
 
-    globalThis.addEventListener("keydown", handleWindowKeyDown);
-    return () => globalThis.removeEventListener("keydown", handleWindowKeyDown);
+    globalThis.addEventListener("keydown", handleKeyDown);
+    return () => globalThis.removeEventListener("keydown", handleKeyDown);
   }, []);
 
   return {

--- a/sudokuru/app/Components/SudokuBoard/Core/Functions/useKeyboardHotkeys.ts
+++ b/sudokuru/app/Components/SudokuBoard/Core/Functions/useKeyboardHotkeys.ts
@@ -48,7 +48,7 @@ export const useKeyboardHotkeys = ({
     const hint = sudokuHintRef.current;
 
     if (
-      handleGlobalHotkeys({
+      handleGeneralHotkeys({
         inputValue,
         board,
         hint,
@@ -65,7 +65,7 @@ export const useKeyboardHotkeys = ({
     handleNavigation(inputValue, board);
   };
 
-  const handleGlobalHotkeys = ({
+  const handleGeneralHotkeys = ({
     inputValue,
     board,
     hint,

--- a/sudokuru/app/Components/SudokuBoard/Core/Functions/useKeyboardHotkeys.ts
+++ b/sudokuru/app/Components/SudokuBoard/Core/Functions/useKeyboardHotkeys.ts
@@ -1,7 +1,10 @@
 import { useEffect, useRef } from "react";
 import { Platform } from "react-native";
-import { doesBoardHaveConflict, wrapDigit } from "./SudokuBoardFunctions";
-import { BoardObjectProps, GameVariant } from "../../Functions/LocalDatabase";
+import { doesBoardHaveConflict, wrapDigit } from "../../SudokuBoardFunctions";
+import {
+  BoardObjectProps,
+  GameVariant,
+} from "../../../../Functions/LocalDatabase";
 
 interface UseKeyboardHotkeysProps {
   boardType: GameVariant;

--- a/sudokuru/app/Components/SudokuBoard/Core/Functions/useKeyboardHotkeys.ts
+++ b/sudokuru/app/Components/SudokuBoard/Core/Functions/useKeyboardHotkeys.ts
@@ -97,7 +97,7 @@ export const useKeyboardHotkeys = ({
     }
 
     if (/^[1-9]$/.test(inputValue)) {
-      updateCellEntryRef.current?.(parseInt(inputValue, 10));
+      updateCellEntryRef.current?.(Number.parseInt(inputValue, 10));
       return;
     }
 
@@ -148,13 +148,13 @@ export const useKeyboardHotkeys = ({
     });
   };
 
-  // Setup keyboard event listeners for web platform using window.addEventListener
+  // Setup keyboard event listeners for web platform using globalThis.addEventListener
   // This allows hotkeys to work without requiring board focus
   useEffect(() => {
     if (Platform.OS !== "web") return;
 
-    window.addEventListener("keydown", handleWindowKeyDown);
-    return () => window.removeEventListener("keydown", handleWindowKeyDown);
+    globalThis.addEventListener("keydown", handleWindowKeyDown);
+    return () => globalThis.removeEventListener("keydown", handleWindowKeyDown);
   }, []);
 
   return {

--- a/sudokuru/app/Components/SudokuBoard/Core/Functions/useKeyboardHotkeys.ts
+++ b/sudokuru/app/Components/SudokuBoard/Core/Functions/useKeyboardHotkeys.ts
@@ -72,7 +72,6 @@ export const useKeyboardHotkeys = ({
     }
     if (handleNavigation(inputValue, board)) {
       event.preventDefault();
-      return;
     }
   };
 

--- a/sudokuru/app/Components/SudokuBoard/Core/Functions/useKeyboardHotkeys.ts
+++ b/sudokuru/app/Components/SudokuBoard/Core/Functions/useKeyboardHotkeys.ts
@@ -3,6 +3,7 @@ import { Platform } from "react-native";
 import { doesBoardHaveConflict, wrapDigit } from "../../SudokuBoardFunctions";
 import {
   BoardObjectProps,
+  CellLocation,
   GameVariant,
 } from "../../../../Functions/LocalDatabase";
 
@@ -10,7 +11,6 @@ interface UseKeyboardHotkeysProps {
   boardType: GameVariant;
   navigation: any;
   boardMethods: any;
-  setSudokuBoard: (board: BoardObjectProps) => void;
 }
 
 /**
@@ -22,7 +22,6 @@ export const useKeyboardHotkeys = ({
   boardType,
   navigation,
   boardMethods,
-  setSudokuBoard,
 }: UseKeyboardHotkeysProps) => {
   const undoRef = useRef<any>(null);
   const toggleNoteModeRef = useRef<any>(null);
@@ -34,6 +33,9 @@ export const useKeyboardHotkeys = ({
   const sudokuBoardRef = useRef<any>(null);
   const sudokuHintRef = useRef<any>(null);
   const gameOverRef = useRef<boolean>(false);
+  const setBoardSelectedCellsRef = useRef<
+    ((cells: CellLocation[]) => void) | null
+  >(null);
 
   /**
    * When a user presses a key down, do the desired action via globalThis.addEventListener
@@ -157,9 +159,11 @@ export const useKeyboardHotkeys = ({
   };
 
   const handleNavigation = (inputValue: string, board: BoardObjectProps) => {
-    for (let i = 0; i < board.selectedCells.length; i++) {
-      let newCol = board.selectedCells[i].c;
-      let newRow = board.selectedCells[i].r;
+    const updatedSelectedCells: CellLocation[] = [];
+
+    for (const cellLocation of board.selectedCells) {
+      let newCol = cellLocation.c;
+      let newRow = cellLocation.r;
       switch (inputValue) {
         case "ArrowLeft":
         case "a":
@@ -184,13 +188,10 @@ export const useKeyboardHotkeys = ({
         default:
           return false;
       }
-      board.selectedCells[i] = { r: newRow, c: newCol };
+      updatedSelectedCells.push({ r: newRow, c: newCol });
     }
 
-    setSudokuBoard({
-      ...board,
-      selectedCells: board.selectedCells,
-    });
+    setBoardSelectedCellsRef.current?.(updatedSelectedCells);
     return true;
   };
 
@@ -214,5 +215,6 @@ export const useKeyboardHotkeys = ({
     sudokuBoardRef,
     sudokuHintRef,
     gameOverRef,
+    setBoardSelectedCellsRef,
   };
 };

--- a/sudokuru/app/Components/SudokuBoard/SudokuBoard.tsx
+++ b/sudokuru/app/Components/SudokuBoard/SudokuBoard.tsx
@@ -125,7 +125,7 @@ const SudokuBoard = (props: Board) => {
       saveGame(game);
       setSudokuBoard(game);
     }
-    // retrigger pipeline
+
     loadGame();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/sudokuru/app/Components/SudokuBoard/SudokuBoard.tsx
+++ b/sudokuru/app/Components/SudokuBoard/SudokuBoard.tsx
@@ -125,7 +125,7 @@ const SudokuBoard = (props: Board) => {
       saveGame(game);
       setSudokuBoard(game);
     }
-
+    // retrigger pipeline
     loadGame();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/sudokuru/app/Components/SudokuBoard/SudokuBoard.tsx
+++ b/sudokuru/app/Components/SudokuBoard/SudokuBoard.tsx
@@ -98,6 +98,7 @@ const SudokuBoard = (props: Board) => {
     updateHintStageRef,
     sudokuBoardRef,
     sudokuHintRef,
+    gameOverRef,
   } = useKeyboardHotkeys({
     boardType: props.type,
     navigation,
@@ -811,6 +812,7 @@ const SudokuBoard = (props: Board) => {
   updateHintStageRef.current = updateHintStage;
   sudokuBoardRef.current = sudokuBoard;
   sudokuHintRef.current = sudokuHint;
+  gameOverRef.current = gameOver;
 
   return (
     <View

--- a/sudokuru/app/Components/SudokuBoard/SudokuBoard.tsx
+++ b/sudokuru/app/Components/SudokuBoard/SudokuBoard.tsx
@@ -36,7 +36,7 @@ import {
   SudokuVariantMethods,
 } from "./SudokuBoardSharedFunctionsController";
 import { DrillStrategy } from "../Home/DrillPanel";
-import { useKeyboardHotkeys } from "./useKeyboardHotkeys";
+import { useKeyboardHotkeys } from "./Core/Functions/useKeyboardHotkeys";
 
 export interface DrillBoard extends CoreBoard<"drill"> {
   action: "StartGame" | "ResumeGame";

--- a/sudokuru/app/Components/SudokuBoard/SudokuBoard.tsx
+++ b/sudokuru/app/Components/SudokuBoard/SudokuBoard.tsx
@@ -99,11 +99,11 @@ const SudokuBoard = (props: Board) => {
     sudokuBoardRef,
     sudokuHintRef,
     gameOverRef,
+    setBoardSelectedCellsRef,
   } = useKeyboardHotkeys({
     boardType: props.type,
     navigation,
     boardMethods,
-    setSudokuBoard,
   });
 
   useEffect(() => {
@@ -813,6 +813,7 @@ const SudokuBoard = (props: Board) => {
   sudokuBoardRef.current = sudokuBoard;
   sudokuHintRef.current = sudokuHint;
   gameOverRef.current = gameOver;
+  setBoardSelectedCellsRef.current = setBoardSelectedCells;
 
   return (
     <View

--- a/sudokuru/app/Components/SudokuBoard/SudokuBoard.tsx
+++ b/sudokuru/app/Components/SudokuBoard/SudokuBoard.tsx
@@ -130,6 +130,9 @@ const SudokuBoard = (props: Board) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Keep keyboard hotkey game-over guard fresh even when this component early-returns
+  gameOverRef.current = gameOver;
+
   // if we are loading then we return the loading icon
   if (sudokuBoard == null) {
     return <ActivityIndicator animating={true} color={theme.colors.error} />;
@@ -812,7 +815,6 @@ const SudokuBoard = (props: Board) => {
   updateHintStageRef.current = updateHintStage;
   sudokuBoardRef.current = sudokuBoard;
   sudokuHintRef.current = sudokuHint;
-  gameOverRef.current = gameOver;
   setBoardSelectedCellsRef.current = setBoardSelectedCells;
 
   return (

--- a/sudokuru/app/Components/SudokuBoard/useKeyboardHotkeys.ts
+++ b/sudokuru/app/Components/SudokuBoard/useKeyboardHotkeys.ts
@@ -1,0 +1,168 @@
+import { useEffect, useRef } from "react";
+import { Platform } from "react-native";
+import { doesBoardHaveConflict, wrapDigit } from "./SudokuBoardFunctions";
+import { BoardObjectProps, GameVariant } from "../../Functions/LocalDatabase";
+
+interface UseKeyboardHotkeysProps {
+  boardType: GameVariant;
+  navigation: any;
+  boardMethods: any;
+  setSudokuBoard: (board: BoardObjectProps) => void;
+}
+
+/**
+ * Custom hook for managing keyboard hotkey refs and event listener
+ * Creates refs for all keyboard-accessible game functions and state,
+ * and sets up the global keyboard event listener that uses these refs
+ */
+export const useKeyboardHotkeys = ({
+  boardType,
+  navigation,
+  boardMethods,
+  setSudokuBoard,
+}: UseKeyboardHotkeysProps) => {
+  const undoRef = useRef<any>(null);
+  const toggleNoteModeRef = useRef<any>(null);
+  const getHintRef = useRef<any>(null);
+  const resetRef = useRef<any>(null);
+  const updateCellEntryRef = useRef<any>(null);
+  const eraseSelectedRef = useRef<any>(null);
+  const updateHintStageRef = useRef<any>(null);
+  const sudokuBoardRef = useRef<any>(null);
+  const sudokuHintRef = useRef<any>(null);
+
+  /**
+   * When a user presses a key down, do the desired action via window.addEventListener
+   * Uses refs to access current state and function implementations
+   * @param event keyboard event
+   * @returns void
+   */
+  const handleWindowKeyDown = (event: KeyboardEvent) => {
+    if (!sudokuBoardRef.current) return;
+
+    const inputValue = event.key;
+    const board = sudokuBoardRef.current;
+    const hint = sudokuHintRef.current;
+
+    switch (inputValue) {
+      case "u":
+      case "U":
+        if (board.actionHistory.length !== 0) {
+          undoRef.current?.();
+        }
+        return;
+      case "p":
+      case "P":
+        boardMethods[boardType].handlePause(board, navigation);
+        return;
+      case "t":
+      case "T":
+      case "n":
+      case "N":
+        toggleNoteModeRef.current?.();
+        return;
+      case "H":
+      case "h":
+        if (
+          !doesBoardHaveConflict(
+            board,
+            boardMethods[boardType].doesCellHaveConflict,
+          )
+        ) {
+          if (hint) {
+            updateHintStageRef.current?.(
+              1,
+              boardMethods[boardType].finishSudokuGame,
+            );
+          } else {
+            getHintRef.current?.();
+          }
+        }
+        return;
+      case "R":
+      case "r":
+        if (boardMethods[boardType].hasResetActionButton() === true) {
+          resetRef.current?.();
+        }
+        return;
+      default:
+        break;
+    }
+
+    if (board.selectedCells.length === 0) {
+      return;
+    }
+
+    if (/^[1-9]$/.test(inputValue)) {
+      updateCellEntryRef.current?.(parseInt(inputValue, 10));
+      return;
+    }
+
+    switch (inputValue) {
+      case "Delete":
+      case "Backspace":
+      case "0":
+      case "e":
+      case "E":
+        if (boardMethods[boardType].hasEraseActionButton() === true) {
+          eraseSelectedRef.current?.();
+        }
+        break;
+    }
+
+    for (let i = 0; i < board.selectedCells.length; i++) {
+      let newCol = board.selectedCells[i].c;
+      let newRow = board.selectedCells[i].r;
+      switch (inputValue) {
+        case "ArrowLeft":
+        case "a":
+        case "A":
+          newCol = wrapDigit(newCol - 1);
+          break;
+        case "ArrowRight":
+        case "d":
+        case "D":
+          newCol = wrapDigit(newCol + 1);
+          break;
+        case "ArrowUp":
+        case "w":
+        case "W":
+          newRow = wrapDigit(newRow - 1);
+          break;
+        case "ArrowDown":
+        case "s":
+        case "S":
+          newRow = wrapDigit(newRow + 1);
+          break;
+        default:
+          return;
+      }
+      board.selectedCells[i] = { r: newRow, c: newCol };
+    }
+    setSudokuBoard({
+      ...board,
+      selectedCells: board.selectedCells,
+    });
+  };
+
+  // Setup keyboard event listeners for web platform using window.addEventListener
+  // This allows hotkeys to work without requiring board focus
+  useEffect(() => {
+    if (Platform.OS !== "web") return;
+
+    window.addEventListener("keydown", handleWindowKeyDown);
+    return () => window.removeEventListener("keydown", handleWindowKeyDown);
+  }, []);
+
+  return {
+    undoRef,
+    toggleNoteModeRef,
+    getHintRef,
+    resetRef,
+    updateCellEntryRef,
+    eraseSelectedRef,
+    updateHintStageRef,
+    sudokuBoardRef,
+    sudokuHintRef,
+  };
+};


### PR DESCRIPTION
## Checklist for completing pull request:
- [x] Update Changelog.json if any functionality has been changed for the end user.
- [x] Test functionality on Mobile and Web
- [x] On mobile, check for warnings / errors in expo dev mode. If we add automated testing we can remove this from the checklist.
- [x] Verify that any tests for new functionality are created and functional.
- [x] SudokuBoard state should only directly be updated in SudokuBoard.tsx file (usage of setSudokuBoard() function)
- [x] If needed, update the Readme

Fixing sudoku board hotkeys so they work even when sudoku board is not selected
closes #336

Reduced cognitive complexity of handleKeyDown function
Updated playwright tests so that they no longer do unnecessary board selections before using hotkeys
Adding `event.preventDefault();` so that sudoku board hotkey events do not have secondary actions. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed Sudoku board hotkeys to work when the board is not selected, improving keyboard navigation and interaction accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->