### PR TITLE
Fixing hot reload (local development) for the ReleaseNotes page

### DIFF
--- a/sudokuru/Changelog.json
+++ b/sudokuru/Changelog.json
@@ -1,7 +1,7 @@
 [
   {
     "version": "1.32.1",
-    "date": "#{date}#",
+    "date": "March 12th, 2026",
     "summary": "Sudoku board hotkeys functionality now works even if the board is not selected.",
     "bug fixes": [
       "Sudoku board hotkeys now work even if the board is not selected. Previously, hotkeys would only work when the user has selected a cell on the board. Hotkeys would stop working when the user clicked away from the sudoku board."

--- a/sudokuru/app/Components/ReleaseNotes/ReleaseNote.tsx
+++ b/sudokuru/app/Components/ReleaseNotes/ReleaseNote.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { View } from "react-native";
 import { Divider, Text } from "react-native-paper";
-import { Theme } from "../../Styling/theme";
+import { useTheme } from "../../Contexts/ThemeContext";
 
 export interface ReleaseNoteInterface {
   version: string;
@@ -14,80 +14,42 @@ export interface ReleaseNoteInterface {
   contributors: string[];
 }
 
+export interface ReleaseNoteProps {
+  item: ReleaseNoteInterface;
+  width: number;
+}
+
 // https://stackoverflow.com/questions/40441877/react-native-bulleted-lists-using-flex-wrap
 // https://stackoverflow.com/questions/39110460/react-native-unordered-style-list
-/**
- * Takes in a string and creates a bullet component
- * @param point a string for the bullet component
- * @param key a key for the view element
- * @returns A JSX element of a bullet
- */
-const BulletComponent = (point: string, key: number, theme: Theme) => {
+const BulletComponent = (point: string, key: number, textColor: string) => {
   return (
     <View
       style={{ flexDirection: "row", paddingLeft: 20, maxWidth: 800 }}
       key={key}
     >
-      <Text style={{ fontSize: 14, color: theme.semantic.text.inverse }}>
-        •
-      </Text>
-      <Text
-        style={{
-          fontSize: 14,
-          paddingLeft: 5,
-          color: theme.semantic.text.inverse,
-        }}
-      >
+      <Text style={{ fontSize: 14, color: textColor }}>•</Text>
+      <Text style={{ fontSize: 14, paddingLeft: 5, color: textColor }}>
         {point}
       </Text>
     </View>
   );
 };
 
-/**
- * Takes in a list of strings and creates a bullet list component
- * @param points A list of strings for the bulleted list component
- * @returns A JSX element of a bullet list component
- */
-const BulletedListComponent = (points: string[], theme: Theme) => {
+const BulletedListComponent = (points: string[], textColor: string) => {
   const list = [];
   for (const [index, point] of points.entries()) {
-    list.push(BulletComponent(point, index, theme));
+    list.push(BulletComponent(point, index, textColor));
   }
   return list;
 };
 
-export const ReleaseNote = (
-  props: ReleaseNoteInterface,
-  key: string,
-  width: number,
-  theme: Theme,
-) => {
-  let featureList = ["None"];
-  if (props.features) {
-    featureList = props.features;
-  }
+export const ReleaseNote = ({ item, width }: ReleaseNoteProps) => {
+  const { theme } = useTheme();
+  const textColor = theme.semantic.text.inverse;
 
-  const featureListComponent = BulletedListComponent(featureList, theme);
-
-  let previewFeatureList = ["None"];
-  if (props["preview features"]) {
-    previewFeatureList = props["preview features"];
-  }
-
-  const previewFeatureListComponent = BulletedListComponent(
-    previewFeatureList,
-    theme,
-  );
-
-  let bugList = ["None"];
-  if (props["bug fixes"]) {
-    bugList = props["bug fixes"];
-  }
-
-  const bugListComponent = BulletedListComponent(bugList, theme);
-  const targetPlatformsString = BulletedListComponent(props.targets, theme);
-  const contributorsString = BulletedListComponent(props.contributors, theme);
+  const featureList = item.features ?? ["None"];
+  const previewFeatureList = item["preview features"] ?? ["None"];
+  const bugList = item["bug fixes"] ?? ["None"];
 
   return (
     <View
@@ -99,49 +61,34 @@ export const ReleaseNote = (
         width: width,
         alignSelf: "center",
       }}
-      key={key}
-      testID={key}
+      testID={item.version}
     >
-      <Text style={{ fontSize: 20, color: theme.semantic.text.inverse }}>
-        Version: {props.version}
+      <Text style={{ fontSize: 20, color: textColor }}>
+        Version: {item.version}
       </Text>
-      <Text style={{ fontSize: 20, color: theme.semantic.text.inverse }}>
-        Release Date: {props.date}
+      <Text style={{ fontSize: 20, color: textColor }}>
+        Release Date: {item.date}
       </Text>
       <Divider style={{ marginBottom: 10 }} />
       <>
-        <Text style={{ fontSize: 20, color: theme.semantic.text.inverse }}>
-          Summary:{" "}
+        <Text style={{ fontSize: 20, color: textColor }}>Summary: </Text>
+        <Text style={{ paddingLeft: 20, fontSize: 14, color: textColor }}>
+          {item.summary}
         </Text>
-        <Text
-          style={{
-            paddingLeft: 20,
-            fontSize: 14,
-            color: theme.semantic.text.inverse,
-          }}
-        >
-          {props.summary}
-        </Text>
-        <Text style={{ fontSize: 20, color: theme.semantic.text.inverse }}>
-          Features:{" "}
-        </Text>
-        {featureListComponent}
-        <Text style={{ fontSize: 20, color: theme.semantic.text.inverse }}>
+        <Text style={{ fontSize: 20, color: textColor }}>Features: </Text>
+        {BulletedListComponent(featureList, textColor)}
+        <Text style={{ fontSize: 20, color: textColor }}>
           Preview Features:{" "}
         </Text>
-        {previewFeatureListComponent}
-        <Text style={{ fontSize: 20, color: theme.semantic.text.inverse }}>
-          Bug Fixes:{" "}
-        </Text>
-        {bugListComponent}
-        <Text style={{ fontSize: 20, color: theme.semantic.text.inverse }}>
+        {BulletedListComponent(previewFeatureList, textColor)}
+        <Text style={{ fontSize: 20, color: textColor }}>Bug Fixes: </Text>
+        {BulletedListComponent(bugList, textColor)}
+        <Text style={{ fontSize: 20, color: textColor }}>
           Target Platforms:{" "}
         </Text>
-        {targetPlatformsString}
-        <Text style={{ fontSize: 20, color: theme.semantic.text.inverse }}>
-          Contributors:{" "}
-        </Text>
-        {contributorsString}
+        {BulletedListComponent(item.targets, textColor)}
+        <Text style={{ fontSize: 20, color: textColor }}>Contributors: </Text>
+        {BulletedListComponent(item.contributors, textColor)}
       </>
     </View>
   );

--- a/sudokuru/app/Components/ReleaseNotes/ReleaseNote.tsx
+++ b/sudokuru/app/Components/ReleaseNotes/ReleaseNote.tsx
@@ -21,6 +21,12 @@ export interface ReleaseNoteProps {
 
 // https://stackoverflow.com/questions/40441877/react-native-bulleted-lists-using-flex-wrap
 // https://stackoverflow.com/questions/39110460/react-native-unordered-style-list
+/**
+ * Takes in a string and creates a bullet component
+ * @param point a string for the bullet component
+ * @param key a key for the view element
+ * @returns A JSX element of a bullet
+ */
 const BulletComponent = (point: string, key: number, textColor: string) => {
   return (
     <View
@@ -35,6 +41,11 @@ const BulletComponent = (point: string, key: number, textColor: string) => {
   );
 };
 
+/**
+ * Takes in a list of strings and creates a bullet list component
+ * @param points A list of strings for the bulleted list component
+ * @returns A JSX element of a bullet list component
+ */
 const BulletedListComponent = (points: string[], textColor: string) => {
   const list = [];
   for (const [index, point] of points.entries()) {

--- a/sudokuru/app/Pages/ReleaseNotesPage.tsx
+++ b/sudokuru/app/Pages/ReleaseNotesPage.tsx
@@ -44,9 +44,10 @@ const ReleaseNotesPage = () => {
         </Text>
       }
       data={releaseNotes}
-      renderItem={({ item }) =>
-        ReleaseNote(item, item.version, componentWidth(width), theme)
-      }
+      keyExtractor={(item) => item.version}
+      renderItem={({ item }) => (
+        <ReleaseNote item={item} width={componentWidth(width)} />
+      )}
     />
   );
 };


### PR DESCRIPTION
## Changelog
- React's Fast Refresh only tracks components — functions called directly are invisible to the hot reload system, so changes to ReleaseNote.tsx never trigger a refresh.

## Checklist for completing pull request:
- [x] Update Changelog.json if any functionality has been changed for the end user.
- [x] Test functionality on Mobile and Web
- [x] On mobile, check for warnings / errors in expo dev mode. If we add automated testing we can remove this from the checklist.
- [x] Verify that any tests for new functionality are created and functional.
- [x] SudokuBoard state should only directly be updated in SudokuBoard.tsx file (usage of setSudokuBoard() function)
- [x] If needed, update the Readme

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated release 1.32.1 date metadata in changelog.

* **Refactor**
  * Streamlined release notes component structure for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->