### PR TITLE
Background color on web updated to match selected theme

### DIFF
--- a/sudokuru/Changelog.json
+++ b/sudokuru/Changelog.json
@@ -2,9 +2,9 @@
   {
     "version": "1.34.1",
     "date": "#{date}#",
-    "summary": "Fixed the background color on web so it always matches your selected theme.",
+    "summary": "Fixed the background color on web so it always matches the user's selected theme.",
     "bug fixes": [
-      "Fixed the background color on web so it always matches your selected theme."
+      "Fixed the background color on web so it always matches the user's selected theme."
     ],
     "targets": ["web"],
     "contributors": ["Thomas-Gallant"]

--- a/sudokuru/Changelog.json
+++ b/sudokuru/Changelog.json
@@ -1,5 +1,15 @@
 [
   {
+    "version": "1.34.1",
+    "date": "#{date}#",
+    "summary": "Fixed the background color on web so it always matches your selected theme.",
+    "bug fixes": [
+      "Fixed the background color on web so it always matches your selected theme."
+    ],
+    "targets": ["web"],
+    "contributors": ["Thomas-Gallant"]
+  },
+  {
     "version": "1.34.0",
     "date": "May 7th, 2026",
     "summary": "Users can now toggle the Sudokuru site theme by pressing t twice.",

--- a/sudokuru/app/Contexts/ThemeContext.tsx
+++ b/sudokuru/app/Contexts/ThemeContext.tsx
@@ -97,6 +97,13 @@ export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
 
   const theme = themes[themeName];
 
+  // Set document.body background on web to match theme
+  useEffect(() => {
+    if (Platform.OS === "web") {
+      document.body.style.backgroundColor = theme.colors.bg;
+    }
+  }, [theme.colors.bg]);
+
   const md3Theme = theme.useDarkTheme ? MD3DarkTheme : MD3LightTheme;
   const navTheme = theme.useDarkTheme
     ? NavigationDarkTheme


### PR DESCRIPTION
Background color on web updated to match selected theme

Before:
<img width="375" height="666" alt="image" src="https://github.com/user-attachments/assets/1f721290-7c06-44a0-9a4c-d823067342ec" />

After:
<img width="375" height="666" alt="image" src="https://github.com/user-attachments/assets/b261654d-6f58-4d71-9460-71d52f6d3822" />


## Checklist for completing pull request:
- [x] Update Changelog.json if any functionality has been changed for the end user.
- [x] Test functionality on Mobile and Web
- [x] On mobile, check for warnings / errors in expo dev mode. If we add automated testing we can remove this from the checklist.
- [x] Verify that any tests for new functionality are created and functional.
- [x] SudokuBoard state should only directly be updated in SudokuBoard.tsx file (usage of setSudokuBoard() function)
- [x] If needed, update the Readme

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue on the web where the page background could become out of sync with the selected theme.
  * The background color now updates automatically whenever the active theme changes.

* **Documentation**
  * Added release notes for version 1.34.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->